### PR TITLE
Attempt to fix an issue where polybuild can't find the config file on MacOS

### DIFF
--- a/Tools/Contents/polybuild/Source/polybuild.cpp
+++ b/Tools/Contents/polybuild/Source/polybuild.cpp
@@ -220,9 +220,11 @@ int main(int argc, char **argv) {
 #endif
 	}
 
+#ifdef _WINDOWS
 	finalPath = finalPath.replace(":", "");
 	finalPath = finalPath.replace("\\", "/");
 	finalPath = finalPath.substr(1, finalPath.length() - 1);
+#endif
 
 	printf("Reading config file from %s\n", finalPath.c_str());
 


### PR DESCRIPTION
I've fixed an issue in polybuild that looks like it came in with some Windows code.  I can't see any use for this block on Unix or Mac, and it does seem to break the path used for the config file.

The output from my broken session looked like:

[scout-2:~/work/polytest] pjh% pwd
/Users/pjh/work/polytest
[scout-2:~/work/polytest] pjh% ~/work/Polycode/Release/Darwin/Framework/Tools/polybuild --config=ExampleProject.xml --out=ExampleProject.polyapp
Polycode build tool v0.1.1
Reading config file from Users/pjh/work/polytest/ExampleProject.xml
Reading xml from Users/pjh/work/polytest/ExampleProject.xml
Error loading xml file: Failed to open file
Specified config file doesn't exist!

and polybuild seemed to strip the forward slash off the front of the config file path.  After applying this commit:

[scout-2:~/work/polytest] pjh% ~/work/Polycode/Release/Darwin/Framework/Tools/polybuild --config=ExampleProject.xml --out=outfile.polyapp
Polycode build tool v0.1.1
Reading config file from /Users/pjh/work/polytest/ExampleProject.xml
Reading xml from /Users/pjh/work/polytest/ExampleProject.xml
OK!
Entry point: ExampleProject.lua
Width: 640
Height: 480
Anti-aliasing level: 0
Background color: 0.250000 0.250000 0.250000
Packaging ExampleProject.lua as ExampleProject.lua

it works as it should.  Hope this helps someone!

Pete.
