### PR TITLE
Fix crash/hang on quit on Windows

### DIFF
--- a/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
+++ b/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
@@ -15,6 +15,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	PAINTSTRUCT ps;
 	HDC hdc;		
 	int nWidth, nHeight;
+	bool useDefault = false;
 
 	if(!core)
 		return DefWindowProc(hWnd, message, wParam, lParam);
@@ -88,14 +89,20 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	case WM_CLOSE:
 		if(core)
 			core->Shutdown();
+		useDefault = true;
 	break;
 	case WM_DESTROY:
 		PostQuitMessage(0);
 		break;
 	default:
-		return DefWindowProc(hWnd, message, wParam, lParam);
+		useDefault = true;
+		break;
 	}
-	return 0;
+	
+	if (useDefault)
+		return DefWindowProc(hWnd, message, wParam, lParam);
+	else
+		return 0;
 }
 
 


### PR DESCRIPTION
As noted in #86, when I build a Windows version of a Polycode program, and send it to a Windows user to test, it does not quit properly-- any attempt to quit, regardless of method, produces a 10-15 second pause seemingly followed by a crash. When I added logging, I noticed that I am receiving WM_CLOSE but not WM_DESTROY.

If I make the change in this patch-- calling DefWindowProc after calling Shutdown on WM_CLOSE and thus allowing the normal WM_CLOSE handling to continue-- I get the WM_CLOSE _and_ the WM_DESTROY, and the program quits politely as it should when the window close button is pressed or alt-f4 is entered. I do not 100% understand how this patch works, but in my tests (compiling with mingw off my bitbucket fork) it seems to.
