### PR TITLE
Repeated calls to Mesh::clearMesh() crash, fix that

### DIFF
--- a/Core/Contents/Source/PolyMesh.cpp
+++ b/Core/Contents/Source/PolyMesh.cpp
@@ -74,9 +74,12 @@ namespace Polycode {
 			if(renderDataArrays[i]) {
 				free(renderDataArrays[i]->arrayPtr);
 				delete renderDataArrays[i];
+				renderDataArrays[i] = NULL;
 			}
 		}
-	
+		
+		meshHasVertexBuffer = false;
+		useVertexColors = false;
 	}
 	
 	VertexBuffer *Mesh::getVertexBuffer() {


### PR DESCRIPTION
Right now calling mesh->clearMesh() twice in a row will crash with a double-free.
