### PR TITLE
NULL-safe String methods

### DIFF
--- a/Core/Contents/Source/PolyString.cpp
+++ b/Core/Contents/Source/PolyString.cpp
@@ -29,15 +29,18 @@ String::String() {
 }
 
 String::String(const wchar_t *str) {
-	wstrToUtf8(contents, str);
+	if (str)
+		wstrToUtf8(contents, str);
 }
 
 String::String(const char *str) {
-	contents = str;
+	if (str)
+		contents = str;
 }
 
 String::String(const char *str, size_t n) {
-	contents = string(str, n);
+	if (str)
+		contents = string(str, n);
 }
 
 String::String(const string& str) {
@@ -76,7 +79,10 @@ const char *String::getDataWithEncoding(int encoding) const {
 void String::setDataWithEncoding(char *data, int encoding) {
 	switch(encoding) {
 		case ENCODING_UTF8: {
-			contents = data;
+			if (data)
+				contents = data;
+			else
+				contents = std::string();
 		}
 		default:
 			break;


### PR DESCRIPTION
Several String methods (constructors, mutators) take char \* as an argument. If NULL is passed into any of these methods, the program will crash. This is particularly worrisome because in several places Polycode itself calls the String constructor with tinyxml->Attribute() as an argument, a method which can sometimes return NULL. So like if you put this in a .mat file:

<param name="xo" type="Number" value="0.0" />

Polycode will crash, because Polycode will check the "default" attribute (not there) and pass the unsanitized result directly to String().

Patch changes String methods to interpret NULL as "empty string".
