### PR TITLE
Sound() should support procedurally generated data

### DIFF
--- a/Core/Contents/Include/PolySound.h
+++ b/Core/Contents/Include/PolySound.h
@@ -90,6 +90,24 @@ namespace Polycode {
 		void setSoundVelocity(Vector3 velocity);
 		void setSoundDirection(Vector3 direction);
 		
+		/**
+		* Sets the current sample offset of this sound.
+		* @param off A number 0 <= off < sound sample length
+		*/
+		void setOffset(int off);
+		
+		/**
+		* Returns the current sample offset (playback progress) of this sound.
+		* @return The sample offset if it is known, -1 otherwise.
+		*/
+		int getOffset();
+		
+		/**
+		* Returns the number of samples in the sound.
+		* @return The sample length if it is known, -1 otherwise.
+		*/
+		int getSampleLength();
+		
 		void setPositionalProperties(Number referenceDistance, Number maxDistance);
 		
 		ALuint loadBytes(const char *data, int size, int channels = 1, ALsizei freq = 44100, int bps = 16);
@@ -109,6 +127,7 @@ namespace Polycode {
 	
 		bool isPositional;
 		ALuint soundSource;
+		int sampleLength;
 		
 	};
 }


### PR DESCRIPTION
ATM, the Sound class can only play data loaded from a file. What if I would prefer to generate a sound in code?

Here is a patch which adds a constructor to Sound which allows it to load sound data from an in-memory buffer.

(I think it might also be interesting to have, like, a Sound() subclass which instead of playing from a fixed buffer is generating data in realtime by repeatedly calling a callback function or something, but I have less idea how to make that happen.)
