### PR TITLE
Require CMake 2.8.5, thus avoiding inscrutable error messages

### DIFF
--- a/Dependencies/CMakeLists.txt
+++ b/Dependencies/CMakeLists.txt
@@ -1,4 +1,4 @@
-CMAKE_MINIMUM_REQUIRED(VERSION 2.8)
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8.5) # 2.8.5 needed for full URL support
 
 PROJECT(PolycodeDependencies)
 


### PR DESCRIPTION
Polycode cannot be built without a fairly recent Cmake, see #103. The "URL_MD5" feature was full of bugs through most of 2.8.x; as far as I can tell\* this was fixed by 2.8.5. What I know for sure is you try to compile Polycode with CMake 2.8.0 or 2.8.2 you will get ugly, inscrutable error messages on the dependency step. This patch makes the Dependencies CMakeLists require 2.8.5, meaning instead of an ugly, inscrutable error message you get a clean, sensible error message ("upgrade to 2.8.5"). I tested the patch with a copy of CMake 2.8.0 on Linux.
- Gory details: There was one bug where if URL_MD5 is specified after URL instead of before it would try to smash the MD5 onto the end of the url (see #103). This bug is work-around-able, but there's almost no point since 2.8.0 didn't support .zip or .bz2 URLs with URL_MD5 either. I did some detective work with a guy from #CMake helping and we think this is the commit that fixed things finally for good: http://cmake.org/gitweb?p=cmake.git;a=commit;h=f67139ae6fdf964218a93e5506722a367e781c6f So I required 2.8.5. It's possible, with ugly workarounds we could get things working as far back as 2.8.2, maybe, but I'm a bit doubtful and maybe ugly workarounds are a bad idea.
