### PR TITLE
Updated external libpng download url in dependencies cmake script

### DIFF
--- a/CMake/ExternalPNG.cmake
+++ b/CMake/ExternalPNG.cmake
@@ -32,7 +32,7 @@ EXTERNALPROJECT_ADD(libpng
     PREFIX ${libpng_PREFIX}
 
     DOWNLOAD_DIR ${POLYCODE_DEPS_DOWNLOAD_DIR}
-    URL ftp://ftp.simplesystems.org/pub/libpng/png/src/libpng-1.5.10.tar.gz
+    URL ftp://ftp.simplesystems.org/pub/libpng/png/src/history/libpng15/libpng-1.5.10.tar.gz
     URL_MD5 9e5d864bce8f06751bbd99962ecf4aad
 
     INSTALL_DIR ${POLYCODE_DEPS_CORE_PREFIX}


### PR DESCRIPTION
- 1.5.10 release appears to have been moved to "history" folder on libpng mirror
- this is not yet reflected on the main libpng site, their links to this mirror are broken as well
- the 1.5.11 release appears to be the new stable, but this has not been announced on the libpng site yet
