### PR TITLE
Added winxp/vista fallback for multitouch functions

### DIFF
--- a/Core/Contents/Include/PolyGlobals.h
+++ b/Core/Contents/Include/PolyGlobals.h
@@ -24,8 +24,6 @@ THE SOFTWARE.
 
 // Polycode CORE LIBRARY CONFIGURATION SECTION
 
-#define WINDOWS_TOUCH_SUPPORT
-
 // Compile support for lua bindings.
 //#define _COMPILE_LUA
 

--- a/Core/Contents/Include/PolyWinCore.h
+++ b/Core/Contents/Include/PolyWinCore.h
@@ -179,10 +179,7 @@ public:
 		void handleMouseWheel(LPARAM lParam, WPARAM wParam);
 		void handleMouseDown(int mouseCode,LPARAM lParam, WPARAM wParam);
 		void handleMouseUp(int mouseCode,LPARAM lParam, WPARAM wParam);
-
-		#ifdef WINDOWS_TOUCH_SUPPORT
-			void handleTouchEvent(LPARAM lParam, WPARAM wParam);
-		#endif
+		void handleTouchEvent(LPARAM lParam, WPARAM wParam);
 
 		void setVideoMode(int xRes, int yRes, bool fullScreen, bool vSync, int aaLevel, int anisotropyLevel);
 		
@@ -213,6 +210,7 @@ public:
 		void shutdownGamepad();
 		void Gamepad_processEvents();
 
+		void initTouch();
 
 		// NEED TO IMPLEMENT:
 
@@ -255,6 +253,15 @@ public:
 		unsigned int PixelFormat;
 		PIXELFORMATDESCRIPTOR pfd;
 		
-
+		// Tracks whether the system supports multitouch at runtime
+		bool hasMultiTouch;
+		
+		// Create generic reference to any multitouch functions we need, so that we
+		// can make them available at runtime if the operating system supports it
+		// while still allowing fallback for older systems
+		// See: http://msdn.microsoft.com/en-us/library/ms683212(v=vs.85).aspx
+		typedef bool (WINAPI *GetTouchInputInfoType)(HTOUCHINPUT,UINT,PTOUCHINPUT,int);
+		GetTouchInputInfoType GetTouchInputInfoFunc;
+		
 	};
 }


### PR DESCRIPTION
- the "GetTouchInputInfo" function in "user32.lib" is only available on windows 7 or greater, see: http://msdn.microsoft.com/en-us/library/windows/desktop/dd371582(v=vs.85).aspx
- polycode will still build on winxp, but any code that uses it fails at runtime with the error: "The procedure entry point GetTouchInputInfo could not be located in the dynamic link library user32.lib"
- using a preprocessor directive wouldn't be helpful here, as that would require always building two release of polycode and any games that use it (one with multitouch support and one without)
- instead, we can check for the existence of any multitouch functions at runtime and fall back to null behavior if they are not available, as described here: http://msdn.microsoft.com/en-us/library/ms683212(v=vs.85).aspx
- removed WINDOWS_TOUCH_SUPPORT preprocessor directive
- added initTouch() for determining multitouch support at runtime
- added check to handleTouchEvent() to return immediately if multitouch is not supported (this may be not be needed, as multitouch events probably won't fire on a system that doesn't support it, right?)
