### PR TITLE
Fixed soundmanager crash on winxp, upgraded to openal-soft 1.14

### DIFF
--- a/CMake/ExternalOpenAL.cmake
+++ b/CMake/ExternalOpenAL.cmake
@@ -15,8 +15,8 @@ ExternalProject_Add(openal
 
     DOWNLOAD_DIR ${POLYCODE_DEPS_DOWNLOAD_DIR}
 
-    URL http://kcat.strangesoft.net/openal-releases/openal-soft-1.13.tar.bz2
-    URL_MD5 58b7d2809790c70681b825644c5f3614
+    URL http://kcat.strangesoft.net/openal-releases/openal-soft-1.14.tar.bz2
+    URL_MD5 3d8b86c21a2f87a2a5e60f78f3b3f03d
     
     INSTALL_DIR ${POLYCODE_DEPS_CORE_PREFIX}
     CMAKE_ARGS ${openal_CMAKE_ARGS}

--- a/Core/Contents/Source/PolySoundManager.cpp
+++ b/Core/Contents/Source/PolySoundManager.cpp
@@ -102,8 +102,11 @@ void SoundManager::setListenerOrientation(Vector3 orientation) {
 }
 
 SoundManager::~SoundManager() {
-	alcSuspendContext(context);
-	alcDestroyContext(context);
+	if (context != 0 ) {
+		alcSuspendContext(context);
+		alcMakeContextCurrent(0);
+		alcDestroyContext(context);
+	}
 	if (device != 0) {
 		alcCloseDevice(device);
 	}


### PR DESCRIPTION
- there is an issue with openal when statically compiled on some win32 platforms, in which the openal dll is unloaded before the public destruction methods can be called (this looks to be a flaw in the original openal spec)
- when this happens, openal crashes on application exit, as it tries to free memory that has already been freed during the dll unload and its own internal cleanup routines
- this always happens on winxp, sometimes on vista, and never on windows 7 (from a cursory google search)
- one workaround is to just not use any of the public destruction methods, and hope openal cleans itself up using its internal "atexit" cleanup routines (though this seems unwise)
- this was fixed in openal-soft 1.14, by making sure the handle to the dll stays open until the application fully exits when openal is statically compiled.  see: http://repo.or.cz/w/openal-soft.git/commitdiff/1a4a0abd1a1fd9a20345db54efef6587bec67197
- now when you call the openal destruction methods from soundmanager (alcCloseDevice, etc) they actually kick off destruction instead of just silently failing or causing a crash (depending on the system)
- added check to soundmanager destruction method to make sure a context exists before trying to destroy it (in case openal init failed and we never created one)
- added call to set "alcMakeContextCurrent" to null before destroying the current context, as per openal spec
