### PR TITLE
Updating win32 c++ template to copy *.pak files to ProjectDir instead of SolutionDir

### DIFF
--- a/Assets/Templates/C++/Windows/Polycode.props
+++ b/Assets/Templates/C++/Windows/Polycode.props
@@ -28,8 +28,8 @@
       <SubSystem>Windows</SubSystem>
     </Link>
     <PostBuildEvent>
-      <Command>if not exist "$(SolutionDir)default.pak" copy "$(PolycodeDir)Core\Assets\default.pak" "$(SolutionDir)"
-if not exist "$(SolutionDir)hdr.pak" copy "$(PolycodeDir)Core\Assets\hdr.pak" "$(SolutionDir)"
+      <Command>if not exist "$(ProjectDir)default.pak" copy "$(PolycodeDir)Core\Assets\default.pak" "$(ProjectDir)"
+if not exist "$(ProjectDir)hdr.pak" copy "$(PolycodeDir)Core\Assets\hdr.pak" "$(ProjectDir)"
 
 if "$(ConfigurationName)" == "Debug" (
   if not exist "$(TargetDir)OpenAL32d.dll" copy "$(PolycodeDir)Core\Dependencies\bin\OpenAL32d.dll" "$(TargetDir)"


### PR DESCRIPTION
- When a project is arranged in a single folder, SolutionDir works just fine
- However, when a project is created using the visual studio 2010 default of using a nested directory, the *.pak files end up in the wrong spot
- Using ProjectDir should let the *.pak files copy to the right spot in both scenarios
