### PR TITLE
Prevent a potential crash when parsing a materials xml containing mistakes

### DIFF
--- a/Core/Contents/Source/PolyMaterialManager.cpp
+++ b/Core/Contents/Source/PolyMaterialManager.cpp
@@ -179,6 +179,9 @@ Shader *MaterialManager::createShaderFromXMLNode(TiXmlNode *node) {
 			}
 		}		
 	}
+	
+	if (!retShader)
+		return NULL;
 
 	int numAreaLights = 0;
 	int numSpotLights = 0;


### PR DESCRIPTION
Right now, if you have a program referencing a nonexistent shader, it just crashes.
