### PR TITLE
PolySound currently leaks OpenAL buffers, eventually breaking OpenAL completely

### DIFF
--- a/Core/Contents/Include/PolySound.h
+++ b/Core/Contents/Include/PolySound.h
@@ -137,7 +137,7 @@ namespace Polycode {
 		ALuint GenSource(ALuint buffer);
 		ALuint GenSource();
 	
-		void checkALError(const String& operation);
+		ALenum checkALError(const String& operation);
 		void soundError(const String& err);
 		void soundCheck(bool result, const String& err);
 		static unsigned long readByte32(const unsigned char buffer[4]);		
@@ -156,6 +156,7 @@ namespace Polycode {
 		bool soundLoaded;
 	
 		bool isPositional;
+		ALuint buffer; // Kept around only for deletion purposes
 		ALuint soundSource;
 		int sampleLength;
 		


### PR DESCRIPTION
Currently, when you create a Sound, it creates a sound source and a buffer. When you delete the Sound, it deletes the sound source, but does not delete the buffer. Besides creating an obvious apparent memory leak, this leads to a VERY nasty problem: If you create and destroy a sufficient number of buffers (say, a couple hundred or so in my testing on mac), OpenAL _loses the ability to create new buffers_ and all new sounds are created mute. I have a program which destroys and creates 14 sounds every time you press a button, so this hit me pretty hard...

This is a bit of a long patch, I cleaned up some confusingly named variables and also added  a bunch of new checks for OpenAL errors. However really the only important line in the patch is:

alDeleteBuffers(1, &buffer);

You could make this line work without keeping around the buffer variable by calling

alGetSourcei(source, AL_BUFFER, &buffer);

But I went this way in case for some reason at some point one wanted to share a buffer between multiple Sounds, this way a Sound is guaranteed to delete only the buffer it created. I think either approach is probably workable.
