### PR TITLE
create_lua_library lua doc generation needs path controls, opt-out

### DIFF
--- a/Bindings/Scripts/create_lua_library/create_lua_library.py
+++ b/Bindings/Scripts/create_lua_library/create_lua_library.py
@@ -62,7 +62,7 @@ def typeFilter(ty):
 	ty = ty.replace(" ", "") # Not very safe!
 	return ty
 
-def createLUABindings(inputPath, prefix, mainInclude, libSmallName, libName, apiPath, apiClassPath, includePath, sourcePath, inheritInModuleFiles):
+def createLUABindings(inputPath, prefix, mainInclude, libSmallName, libName, apiPath, apiClassPath, includePath, sourcePath, luaDocPath, inheritInModuleFiles):
 	wrappersHeaderOut = "" # Def: Global C++ *LUAWrappers.h
 	cppRegisterOut = "" # Def: Global C++ *LUA.cpp
 	cppLoaderOut = "" # Def: Global C++ *LUA.cpp
@@ -789,9 +789,11 @@ def createLUABindings(inputPath, prefix, mainInclude, libSmallName, libName, api
 	fout = open("%s/%sLUA.h" % (includePath, prefix), "w")
 	fout.write(cppRegisterHeaderOut)
 
-	luaDocPath = "../../../Documentation/Lua/xml"
-	fout = open("%s/%s.xml" % (luaDocPath, prefix), "w")
-	fout.write(luaDocOut)
+	if luaDocPath is None:
+		luaDocPath = "../../../Documentation/Lua/xml"
+	if luaDocPath != "-":
+		fout = open("%s/%s.xml" % (luaDocPath, prefix), "w")
+		fout.write(luaDocOut)
 
 	fout = open("%s/%s.lua" % (apiPath, prefix), "w")
 	fout.write(luaIndexOut)
@@ -817,7 +819,7 @@ def createLUABindings(inputPath, prefix, mainInclude, libSmallName, libName, api
 					myzip.write(os.path.join(root, filename))
 
 if len(sys.argv) < 10:
-	print ("Usage:\n%s [input path] [prefix] [main include] [lib small name] [lib name] [api path] [api class-path] [include path] [source path] [inherit-in-module-file path (optional)]" % (sys.argv[0]))
+	print ("Usage:\n%s [input path] [prefix] [main include] [lib small name] [lib name] [api path] [api class-path] [include path] [source path] [lua doc path (optional) (or - for omit)] [inherit-in-module-file path (optional)]" % (sys.argv[0]))
 	sys.exit(1)
 else:
-	createLUABindings(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7], sys.argv[8], sys.argv[9], sys.argv[10] if len(sys.argv)>10 else None)
+	createLUABindings(sys.argv[1], sys.argv[2], sys.argv[3], sys.argv[4], sys.argv[5], sys.argv[6], sys.argv[7], sys.argv[8], sys.argv[9], sys.argv[10] if len(sys.argv)>10 else None, sys.argv[11] if len(sys.argv)>11 else None)


### PR DESCRIPTION
Not certain if this is the exact best way to do this, but...

A recent update adds lua doc generation. This breaks my local project.
1. Users of create_lua_library library won't _always_ want lua docs.
2. The luaDocPath is _HARDCODED_, obviously breaking any attempts to run create_lua_library against anything other than Polycode itself.

Solution: add an optional luaDocPath argument. If omitted, this falls back on using the current hardcoded path as a default. If the argument is equal to "-" then lua docs are not written at all.
