### PR TITLE
Pervasive leaks and memory unsafety in UI module

### DIFF
--- a/Core/Contents/Source/PolyTween.cpp
+++ b/Core/Contents/Source/PolyTween.cpp
@@ -65,7 +65,9 @@ void Tween::setSpeed(Number speed) {
 Tween::~Tween() {
 	tweenTimer->removeEventListener(this, 0);
 	delete tweenTimer;
-	CoreServices::getInstance()->getTweenManager()->removeTween(this);	
+	
+	deleteOnComplete = false; // Prevent loop when we removeTween in next line.
+	CoreServices::getInstance()->getTweenManager()->removeTween(this);
 }
 
 bool Tween::isComplete() {

--- a/Modules/Contents/UI/Include/PolyUIColorBox.h
+++ b/Modules/Contents/UI/Include/PolyUIColorBox.h
@@ -85,6 +85,8 @@ namespace Polycode {
 			UIHSlider *alphaSlider;
 			
 			ScreenShape *mainColorRect;
+			
+			vector<ScreenLabel *> junkLabels; // Kept only to delete
 	};
 
 	class _PolyExport UIColorBox : public UIElement {

--- a/Modules/Contents/UI/Include/PolyUIMenu.h
+++ b/Modules/Contents/UI/Include/PolyUIMenu.h
@@ -55,7 +55,6 @@ namespace Polycode {
 			
 		protected:
 		
-			ScreenImage *dropDownImage;
 			Number menuItemHeight;
 			Number menuWidth;
 			

--- a/Modules/Contents/UI/Include/PolyUIWindow.h
+++ b/Modules/Contents/UI/Include/PolyUIWindow.h
@@ -71,5 +71,8 @@ namespace Polycode {
 			UIImageButton *closeBtn;
 			UIBox *windowRect;
 			ScreenShape *titlebarRect;
+		
+			bool tweenClosing;
+			void resetTween();
 	};
 }

--- a/Modules/Contents/UI/Source/PolyUIButton.cpp
+++ b/Modules/Contents/UI/Source/PolyUIButton.cpp
@@ -91,7 +91,9 @@ void UIButton::Update() {
 }
 
 UIButton::~UIButton() {
-
+	delete buttonRect;
+	delete buttonFocusedRect;
+	delete buttonLabel;
 }
 		
 void UIButton::handleEvent(Event *event) {

--- a/Modules/Contents/UI/Source/PolyUICheckBox.cpp
+++ b/Modules/Contents/UI/Source/PolyUICheckBox.cpp
@@ -38,9 +38,9 @@ UICheckBox::UICheckBox(String caption, bool checked) : UIElement() {
 	String uncheckImage = conf->getStringValue("Polycode", "uiCheckBoxUncheckedImage");
 	Number checkboxTextOffsetX = conf->getNumericValue("Polycode", "uiCheckBoxLabelOffsetX");
 	Number checkboxTextOffsetY = conf->getNumericValue("Polycode", "uiCheckBoxLabelOffsetY");
-		
+	
 	this->checked = checked;
-		
+	
 	buttonImageChecked = new ScreenImage(checkImage);
 	buttonImageChecked->visible = checked;
 
@@ -67,7 +67,6 @@ UICheckBox::UICheckBox(String caption, bool checked) : UIElement() {
 	
 	height = buttonImageUnchecked->getHeight();
 	width = buttonImageUnchecked->getWidth() + captionLabel->getWidth() + checkboxTextOffsetX;
-	
 }
 
 String UICheckBox::getCaptionLabel() {
@@ -75,7 +74,9 @@ String UICheckBox::getCaptionLabel() {
 }
 
 UICheckBox::~UICheckBox() {
-
+	delete buttonImageChecked;
+	delete buttonImageUnchecked;
+	delete captionLabel;
 }
 
 bool UICheckBox::isChecked() {

--- a/Modules/Contents/UI/Source/PolyUIColorBox.cpp
+++ b/Modules/Contents/UI/Source/PolyUIColorBox.cpp
@@ -95,6 +95,7 @@ UIColorPicker::UIColorPicker() : UIWindow(L"", 300, 240) {
 	ScreenLabel *label = new ScreenLabel(L"R:", fontSize, fontName);
 	label->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 15, topPadding+padding + 3);
 	addChild(label);
+	junkLabels.push_back(label);
 	
 	rTextInput = new UITextInput(false, 40, 12);
 	rTextInput->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 30, topPadding+padding);
@@ -104,6 +105,7 @@ UIColorPicker::UIColorPicker() : UIWindow(L"", 300, 240) {
 	label = new ScreenLabel(L"G:", fontSize, fontName);
 	label->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 15, topPadding+padding + 33);
 	addChild(label);
+	junkLabels.push_back(label);
 	
 	gTextInput = new UITextInput(false, 40, 12);
 	gTextInput->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 30, topPadding+padding + 30);
@@ -113,6 +115,7 @@ UIColorPicker::UIColorPicker() : UIWindow(L"", 300, 240) {
 	label = new ScreenLabel(L"B:", fontSize, fontName);
 	label->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 15, topPadding+padding + 63);
 	addChild(label);
+	junkLabels.push_back(label);
 	
 	bTextInput = new UITextInput(false, 40, 12);
 	bTextInput->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 30, topPadding+padding + 60);
@@ -122,6 +125,7 @@ UIColorPicker::UIColorPicker() : UIWindow(L"", 300, 240) {
 	label = new ScreenLabel(L"A:", fontSize, fontName);
 	label->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 15, topPadding+padding + 93);
 	addChild(label);
+	junkLabels.push_back(label);
 	
 	aTextInput = new UITextInput(false, 40, 12);
 	aTextInput->setPosition(hueFrame->getPosition().x+hueFrame->getWidth() + 30, topPadding+padding + 90);
@@ -339,7 +343,20 @@ void UIColorPicker::setHue(Number hueNum) {
 }
 
 UIColorPicker::~UIColorPicker() {
-
+	delete mainBg;
+	delete mainFrame;
+	delete alphaSlider;
+	delete mainColorRect;
+	delete hueFrame;
+	delete hueSelector;
+	delete mainSelector;
+	delete rTextInput;
+	delete gTextInput;
+	delete bTextInput;
+	delete aTextInput;
+	
+	for(int c = 0; c < junkLabels.size(); c++)
+		delete junkLabels[c];
 }
 
 void UIColorPicker::Update() {
@@ -428,6 +445,10 @@ Color UIColorBox::getSelectedColor() {
 
 UIColorBox::~UIColorBox() {
 	colorPicker->removeAllHandlersForListener(this);
+	
+	delete bgImage;
+	delete colorShape;
+	delete frameImage;
 }
 
 void UIColorBox::setBoxColor(Color newColor) {

--- a/Modules/Contents/UI/Source/PolyUIComboBox.cpp
+++ b/Modules/Contents/UI/Source/PolyUIComboBox.cpp
@@ -101,7 +101,12 @@ UIComboBox::UIComboBox(UIGlobalMenu *globalMenu, Number comboWidth) : UIElement(
 }
 
 UIComboBox::~UIComboBox() {
-
+	for(int c = 0; c < items.size(); c++)
+		delete items[c];
+	
+	delete dropDownImage;
+	delete bgBox;
+	delete selectedLabel;
 }
 
 void UIComboBox::clearItems() {

--- a/Modules/Contents/UI/Source/PolyUIHScrollBar.cpp
+++ b/Modules/Contents/UI/Source/PolyUIHScrollBar.cpp
@@ -172,5 +172,6 @@ void UIHScrollBar::handleEvent(Event *event) {
 
 
 UIHScrollBar::~UIHScrollBar() {
-	
+	delete bgBox;
+	delete handleBox;
 }

--- a/Modules/Contents/UI/Source/PolyUIHSizer.cpp
+++ b/Modules/Contents/UI/Source/PolyUIHSizer.cpp
@@ -74,7 +74,14 @@ UIHSizer::UIHSizer(Number width, Number height, Number mainWidth, bool leftSizer
 }
 
 UIHSizer::~UIHSizer() {
-
+	coreInput->removeAllHandlersForListener(this);
+	
+	if (ownsChildren)
+		childElements->ownsChildren = true;
+	delete childElements;
+	
+	delete separatorBgShape;
+	delete separatorHitShape;
 }
 
 void UIHSizer::handleEvent(Event *event) {

--- a/Modules/Contents/UI/Source/PolyUIHSlider.cpp
+++ b/Modules/Contents/UI/Source/PolyUIHSlider.cpp
@@ -78,7 +78,9 @@ UIHSlider::UIHSlider(Number start, Number end, Number width) : UIElement() {
 }
 
 UIHSlider::~UIHSlider() {
-
+	delete bgRect;
+	delete gripRect;
+	delete bgHitBox;
 }
 
 void UIHSlider::setSliderValue(Number val) {

--- a/Modules/Contents/UI/Source/PolyUIImageButton.cpp
+++ b/Modules/Contents/UI/Source/PolyUIImageButton.cpp
@@ -76,5 +76,6 @@ void UIImageButton::handleEvent(Event *event) {
 }
 
 UIImageButton::~UIImageButton() {
-
+	delete buttonImage;
+	delete buttonRect;
 }

--- a/Modules/Contents/UI/Source/PolyUIMenu.cpp
+++ b/Modules/Contents/UI/Source/PolyUIMenu.cpp
@@ -47,12 +47,10 @@ UIMenuItem::UIMenuItem(String label, String _id, void *data, Number comboWidth, 
 	
 	this->_id = _id;
 	this->data = data;
-
-
 }
 
 UIMenuItem::~UIMenuItem() {
-		
+	delete itemLabel;
 }
 
 UIMenu::UIMenu(Number menuWidth) : UIElement() {
@@ -178,6 +176,12 @@ void UIMenu::handleEvent(Event *event) {
 
 
 UIMenu::~UIMenu() {
+	for(int c = 0; c < items.size(); c++)
+		delete items[c];
+	
+	delete dropDownBox;
+	delete selectorBox;
+	
 	CoreServices::getInstance()->getCore()->getInput()->removeAllHandlersForListener(this);
 }
 

--- a/Modules/Contents/UI/Source/PolyUIScrollContainer.cpp
+++ b/Modules/Contents/UI/Source/PolyUIScrollContainer.cpp
@@ -191,5 +191,6 @@ void UIScrollContainer::handleEvent(Event *event) {
 }
 
 UIScrollContainer::~UIScrollContainer() {
-	
+	delete vScrollBar;
+	delete hScrollBar;
 }

--- a/Modules/Contents/UI/Source/PolyUITextInput.cpp
+++ b/Modules/Contents/UI/Source/PolyUITextInput.cpp
@@ -1363,7 +1363,15 @@ void UITextInput::Update() {
 }
 
 UITextInput::~UITextInput() {
-
+	delete linesContainer;
+	delete inputRect;
+	delete lineNumberBg;
+	delete lineNumberAnchor;
+	delete selectorRectTop;
+	delete selectorRectMiddle;
+	delete selectorRectBottom;
+	delete blinkerRect;
+	delete blinkTimer;
 }
 
 void UITextInput::readjustBuffer() {

--- a/Modules/Contents/UI/Source/PolyUITree.cpp
+++ b/Modules/Contents/UI/Source/PolyUITree.cpp
@@ -249,14 +249,14 @@ void UITree::clearSelection(UITree *selectedNode) {
 
 void UITree::refreshTree() {
 	if(collapsed) {
-		new Tween(&handleRotation, Tween::EASE_IN_QUAD, handleRotation, 0, 0.2f);
+		new Tween(&handleRotation, Tween::EASE_IN_QUAD, handleRotation, 0, 0.2f, false, true);
 		for(int i=0; i < treeChildren.size(); i++) {
 			treeChildren[i]->visible = false;
 			treeChildren[i]->enabled = false;			
 		}
 		treeHeight = 0;
 	} else {
-		new Tween(&handleRotation, Tween::EASE_IN_QUAD, handleRotation, 90, 0.2f);
+		new Tween(&handleRotation, Tween::EASE_IN_QUAD, handleRotation, 90, 0.2f, false, true);
 		int offset = cellHeight;
 		for(int i=0; i < treeChildren.size(); i++) {
 			treeChildren[i]->visible = true;
@@ -286,6 +286,12 @@ void UITree::toggleCollapsed() {
 
 UITree::~UITree() {
 	clearTree();
+	
+	delete textLabel;
+	delete bgBox;
+	delete selection;
+	delete arrowIconImage;
+	delete iconImage;
 }
 
 void UITree::clearTree() {

--- a/Modules/Contents/UI/Source/PolyUITreeContainer.cpp
+++ b/Modules/Contents/UI/Source/PolyUITreeContainer.cpp
@@ -91,5 +91,8 @@ UITree *UITreeContainer::getRootNode() {
 }
 
 UITreeContainer::~UITreeContainer() {
-	
+	delete bgBox;
+	delete scrollChild;
+	delete rootNode;
+	delete mainContainer;
 }

--- a/Modules/Contents/UI/Source/PolyUIVScrollBar.cpp
+++ b/Modules/Contents/UI/Source/PolyUIVScrollBar.cpp
@@ -205,5 +205,6 @@ void UIVScrollBar::handleEvent(Event *event) {
 	
 
 UIVScrollBar::~UIVScrollBar() {
-	
+	delete bgBox;
+	delete handleBox;
 }

--- a/Modules/Contents/UI/Source/PolyUIVSizer.cpp
+++ b/Modules/Contents/UI/Source/PolyUIVSizer.cpp
@@ -74,7 +74,14 @@ UIVSizer::UIVSizer(Number width, Number height, Number mainHeight, bool topSizer
 }
 
 UIVSizer::~UIVSizer() {
-
+	coreInput->removeAllHandlersForListener(this);
+	
+	if (ownsChildren)
+		childElements->ownsChildren = true;
+	delete childElements;
+	
+	delete separatorBgShape;
+	delete separatorHitShape;
 }
 
 void UIVSizer::handleEvent(Event *event) {

--- a/Modules/Contents/UI/Source/PolyUIWindow.cpp
+++ b/Modules/Contents/UI/Source/PolyUIWindow.cpp
@@ -30,8 +30,7 @@
 using namespace Polycode;
 
 
-UIWindow::UIWindow(String windowName, Number width, Number height) : ScreenEntity() {
-	
+UIWindow::UIWindow(String windowName, Number width, Number height) : ScreenEntity(), windowTween(NULL) {
 	closeOnEscape = false;
 	
 	snapToPixels = true;
@@ -112,11 +111,14 @@ void UIWindow::setWindowSize(Number w, Number h) {
 }
 
 UIWindow::~UIWindow() {
-
+	delete windowTween;
+	delete windowRect;
+	delete titlebarRect;
+	delete titleLabel;
+	delete closeBtn;
 }
 
 void UIWindow::onKeyDown(PolyKEY key, wchar_t charCode) {
-	
 	if(key == KEY_TAB) {
 		if(hasFocus) {
 			focusNextChild();
@@ -152,20 +154,24 @@ void UIWindow::onMouseDown(Number x, Number y) {
 }
 
 void UIWindow::showWindow() {
-//	if(!visible) {
-		enabled = true;
-		visible = true;
-		windowTween = new Tween(&color.a, Tween::EASE_IN_QUAD, 0.0f, 1.0f, 0.01f);
-//	}
+	if (windowTween)
+		delete windowTween;
+
+	enabled = true;
+	visible = true;
+	tweenClosing = false;
+	windowTween = new Tween(&color.a, Tween::EASE_IN_QUAD, 0.0f, 1.0f, 0.01f, false, true);
+	windowTween->addEventListener(this, Event::COMPLETE_EVENT);
 }
 
 void UIWindow::hideWindow() {
-//	if(visible) {
-		windowTween = new Tween(&color.a, Tween::EASE_IN_QUAD, 1.0f, 0.0f, 0.01f);
-		windowTween->addEventListener(this, Event::COMPLETE_EVENT);
-//	}
-}
+	if (windowTween)
+		delete windowTween;
 
+	tweenClosing = true;
+	windowTween = new Tween(&color.a, Tween::EASE_IN_QUAD, 1.0f, 0.0f, 0.01f, false, true);
+	windowTween->addEventListener(this, Event::COMPLETE_EVENT);
+}
 
 void UIWindow::handleEvent(Event *event) {
 	if(event->getDispatcher() == titlebarRect) {
@@ -185,8 +191,11 @@ void UIWindow::handleEvent(Event *event) {
 		dispatchEvent(new UIEvent(), UIEvent::CLOSE_EVENT);
 	}
 	if(event->getDispatcher() == windowTween) {
-		visible = false;
-		enabled = false;		
-		windowTween->removeEventListener(this, Event::COMPLETE_EVENT);
+		if (tweenClosing) {
+			visible = false;
+			enabled = false;
+		}
+		
+		windowTween = NULL;
 	}
 }


### PR DESCRIPTION
Run the UIDemo.lua currently in the Polycode repo. Okay, now delete all those objects you just created. The Polycode Player will promptly crash.

This patch fixes the following:
- Most UI module classes were not deleting their children, causing leaks.
- Important classes in UI module were not unregistering their listeners on delete, causing crashes.
- UIWindow had a thing where something really ugly would happen if you performed a show/hide before the last show/hide was complete.
- Outside the UI module, Tweens had a problem where manually deleting a Tween with "delete on complete" flag would cause an infinite loop.
