### PR TITLE
Give some way to recover from CoreInput::removeAllHandlers()

### DIFF
--- a/Core/Contents/Include/PolyCoreServices.h
+++ b/Core/Contents/Include/PolyCoreServices.h
@@ -67,6 +67,11 @@ namespace Polycode {
 			void Update(int elapsed);
 			
 			void setCore(Core *core);
+		
+			/**
+			* Reloads the event listeners CoreServices configures as part of construction/setCore. Useful if removeAllListeners is called on the core input object.
+			*/
+			void setupBasicListeners();
 			
 			/**
 			* Returns the core. 

--- a/Core/Contents/Source/PolyCoreServices.cpp
+++ b/Core/Contents/Source/PolyCoreServices.cpp
@@ -113,6 +113,10 @@ void CoreServices::installModule(PolycodeModule *module)  {
 	}
 }
 
+void CoreServices::setupBasicListeners() {
+	this->setCore(this->core);	
+}
+
 CoreServices::CoreServices() : EventDispatcher() {
 	resourceManager = new ResourceManager();	
 	config = new Config();
@@ -122,12 +126,12 @@ CoreServices::CoreServices() : EventDispatcher() {
 	addEventListener(screenManager, InputEvent::EVENT_MOUSEMOVE);
 	addEventListener(screenManager, InputEvent::EVENT_MOUSEUP);
 	addEventListener(screenManager, InputEvent::EVENT_MOUSEWHEEL_UP);
-	addEventListener(screenManager, InputEvent::EVENT_MOUSEWHEEL_DOWN);	
+	addEventListener(screenManager, InputEvent::EVENT_MOUSEWHEEL_DOWN);
 	addEventListener(screenManager, InputEvent::EVENT_KEYDOWN);
-	addEventListener(screenManager, InputEvent::EVENT_KEYUP);	
-	addEventListener(screenManager, InputEvent::EVENT_TOUCHES_BEGAN);	
-	addEventListener(screenManager, InputEvent::EVENT_TOUCHES_ENDED);	
-	addEventListener(screenManager, InputEvent::EVENT_TOUCHES_MOVED);				
+	addEventListener(screenManager, InputEvent::EVENT_KEYUP);
+	addEventListener(screenManager, InputEvent::EVENT_TOUCHES_BEGAN);
+	addEventListener(screenManager, InputEvent::EVENT_TOUCHES_ENDED);
+	addEventListener(screenManager, InputEvent::EVENT_TOUCHES_MOVED);
 	sceneManager = new SceneManager();
 	timerManager = new TimerManager();
 	tweenManager = new TweenManager();


### PR DESCRIPTION
The core->getInput() object has a method removeAllHandlers(). When my "player" implementation is unloading a Lua program, it calls removeAllHandlers() to make TOTALLY CERTAIN nothing survives from the run of one program to the next (as this could cause a crash).

However this creates a problem. CoreServices, on setting the core, wires up many input handlers for the Screen Manager, meaning any call to CoreInput's removeAllHandlers effectively permanently breaks Polycore. Although any user would surely realize removeAllHandlers is a "dangerous" operation, it still seems like something an informed user should be able to do while still leaving Polycode functional.

I don't know what the best solution here is, but what I settled on was adding a setupBasicHandlers() method on CoreServices which resets the current (and future?) CoreServices-owned event handlers, thus meaning a clued-in user can make the destructive removeAllHandlers() call and then be able to get back to a working state.

Yeah, this writeup is totally several times longer than the actual patch
