### PR TITLE
Prevent event-code collisions when using Polycode stock classes

### DIFF
--- a/Bindings/Scripts/create_lua_library/create_lua_library.py
+++ b/Bindings/Scripts/create_lua_library/create_lua_library.py
@@ -220,7 +220,15 @@ def createLUABindings(inputPath, prefix, mainInclude, libSmallName, libName, api
 						continue
 					if pp["type"].find("static ") != -1: # If static. FIXME: Static doesn't work?
 						if "defaltValue" in pp: # FIXME: defaltValue is misspelled.
-							luaClassBindingOut += "%s.%s = %s\n" % (ckey, pp["name"], pp["defaltValue"])
+							defaltValue = pp["defaltValue"]
+							
+							# The "Default Value" is more or less a literal C++ string. This causes a problem:
+							# Frequently we say static const int A = 1; static const int B = A + 1.
+							# Put in a one-off hack to ensure namespacing works in this special case.
+							if re.match(r'\s*[a-zA-Z_][a-zA-Z0-9_]*\s*\+', defaltValue):
+								defaltValue = "%s.%s" % (ckey, defaltValue)
+							
+							luaClassBindingOut += "%s.%s = %s\n" % (ckey, pp["name"], defaltValue)
 							luaDocOut += "\t\t\t<static_member name=\"%s\" type=\"%s\" value=\"%s\">\n" % (pp["name"],  toLuaType(typeFilter(pp["type"])), pp["defaltValue"])
 							if 'doxygen' in pp:
 								luaDocOut += "\t\t\t\t<desc><![CDATA[%s]]></desc>\n" % (cleanDocs(pp['doxygen']))

--- a/Core/Contents/Include/PolyClient.h
+++ b/Core/Contents/Include/PolyClient.h
@@ -41,10 +41,11 @@ namespace Polycode {
 		char data[MAX_PACKET_SIZE];
 		unsigned int dataSize;
 		unsigned short dataType;
-				
-		static const int EVENT_SERVER_DATA = 0;
-		static const int EVENT_CLIENT_READY = 1;		
-		static const int EVENT_SERVER_DISCONNECTED = 2;			
+		
+		static const int EVENTBASE_CLIENTEVENT = 0x600;
+		static const int EVENT_SERVER_DATA = EVENTBASE_CLIENTEVENT+0;
+		static const int EVENT_CLIENT_READY = EVENTBASE_CLIENTEVENT+1;
+		static const int EVENT_SERVER_DISCONNECTED = EVENTBASE_CLIENTEVENT+2;
 	};		
 	
 	class _PolyExport Client : public Peer {

--- a/Core/Contents/Include/PolyCocoaCore.h
+++ b/Core/Contents/Include/PolyCocoaCore.h
@@ -64,8 +64,9 @@ namespace Polycode {
 		
 		char mouseButton;
 		
-		static const int INPUT_EVENT = 0;
-		static const int FOCUS_EVENT = 1;		
+		static const int EVENTBASE_PLATFORMEVENT = 0x300;
+		static const int INPUT_EVENT = EVENTBASE_PLATFORMEVENT+0;
+		static const int FOCUS_EVENT = EVENTBASE_PLATFORMEVENT+1;
 	};
 	
 	

--- a/Core/Contents/Include/PolyCore.h
+++ b/Core/Contents/Include/PolyCore.h
@@ -241,12 +241,10 @@ namespace Polycode {
 		/**
 		* Opens a system folder picker and suspends operation.
 		* @return The selected path returned from the picker.
-		*/		
-		
+		*/
+		virtual String openFolderPicker() = 0;
 
 		void setFramerate(int frameRate);
-
-		virtual String openFolderPicker() = 0;
 		
 		/**
 		* Opens a system file picker for the specified extensions.
@@ -303,16 +301,17 @@ namespace Polycode {
 		void setUserPointer(void *ptr) { userPointer = ptr; }
 		void *getUserPointer() { return userPointer; }
 		
-		static const int EVENT_CORE_RESIZE = 0;		
-		static const int EVENT_LOST_FOCUS = 1;
-		static const int EVENT_GAINED_FOCUS = 2;
+		static const int EVENTBASE_CORE = 0x200;
+		static const int EVENT_CORE_RESIZE = EVENTBASE_CORE+0;
+		static const int EVENT_LOST_FOCUS = EVENTBASE_CORE+1;
+		static const int EVENT_GAINED_FOCUS = EVENTBASE_CORE+2;
 
-		static const int EVENT_UNDO = 3;
-		static const int EVENT_REDO = 4;
-		static const int EVENT_COPY = 5;
-		static const int EVENT_CUT = 6;
-		static const int EVENT_SELECT_ALL = 7;
-		static const int EVENT_PASTE = 8;
+		static const int EVENT_UNDO = EVENTBASE_CORE+3;
+		static const int EVENT_REDO = EVENTBASE_CORE+4;
+		static const int EVENT_COPY = EVENTBASE_CORE+5;
+		static const int EVENT_CUT = EVENTBASE_CORE+6;
+		static const int EVENT_SELECT_ALL = EVENTBASE_CORE+7;
+		static const int EVENT_PASTE = EVENTBASE_CORE+8;
 		
 		virtual String executeExternalCommand(String command, String args, String inDirectory) = 0;
 		

--- a/Core/Contents/Include/PolyEvent.h
+++ b/Core/Contents/Include/PolyEvent.h
@@ -61,10 +61,29 @@ namespace Polycode {
 			void setDispatcher(EventDispatcher *dispatcher);
 			const String& getEventType() const;
 			
-			static const int COMPLETE_EVENT = 0;
-			static const int CHANGE_EVENT = 1;
-			static const int CANCEL_EVENT = 2;			
+			// In order to prevent "namespace" collisions between events of different types, all event integers must be unique.
+			// This is managed by arbitrarily assigning each class a "base" constant, and adding it to all its event type constants.
+			// Bases for all Polycode classes are documented below, third party event types should be EVENTBASE_NONPOLYCODE or over.
+			// Note that collisions are usually safe as long as collisions do not occur between a class and its subclass.
+			// Event		0x100
+			// Core			0x200
+			// PlatformCore 0x300 (e.g. CocoaCore, WinCore etc)
+			// InputEvent	0x400
+			// SocketEvent	0x500
+			// ClientEvent	0x600
+			// ServerEvent	0x700
+			// PhysicsScreenEvent	0x800
+			// PhysicsSceneEvent	0x900
+			// UIEvent		0xA00
+			// UITreeEvent	0xB00
+		
+			static const int EVENTBASE_EVENT = 0x100;
+			static const int COMPLETE_EVENT = EVENTBASE_EVENT+0;
+			static const int CHANGE_EVENT = EVENTBASE_EVENT+1;
+			static const int CANCEL_EVENT = EVENTBASE_EVENT+2;
 			
+			static const int EVENTBASE_NONPOLYCODE = 0x10000;
+		
 			bool deleteOnDispatch;
 						
 		protected:

--- a/Core/Contents/Include/PolyInputEvent.h
+++ b/Core/Contents/Include/PolyInputEvent.h
@@ -50,28 +50,29 @@ namespace Polycode {
 			*  Possible input event types dispatched by CoreInput.
 			*/
 			//@{
-		static const int EVENT_MOUSEDOWN = 0;
-		static const int EVENT_MOUSEUP = 1;
-		static const int EVENT_MOUSEMOVE = 2;
-		static const int EVENT_MOUSEOVER = 3;
-		static const int EVENT_MOUSEOUT = 4;
-		static const int EVENT_DOUBLECLICK = 5;
-		static const int EVENT_MOUSEUP_OUTSIDE = 6;
-		static const int EVENT_MOUSEWHEEL_UP = 7;
-		static const int EVENT_MOUSEWHEEL_DOWN = 8;
+		static const int EVENTBASE_INPUTEVENT = 0x400;
+		static const int EVENT_MOUSEDOWN = EVENTBASE_INPUTEVENT+0;
+		static const int EVENT_MOUSEUP = EVENTBASE_INPUTEVENT+1;
+		static const int EVENT_MOUSEMOVE = EVENTBASE_INPUTEVENT+2;
+		static const int EVENT_MOUSEOVER = EVENTBASE_INPUTEVENT+3;
+		static const int EVENT_MOUSEOUT = EVENTBASE_INPUTEVENT+4;
+		static const int EVENT_DOUBLECLICK = EVENTBASE_INPUTEVENT+5;
+		static const int EVENT_MOUSEUP_OUTSIDE = EVENTBASE_INPUTEVENT+6;
+		static const int EVENT_MOUSEWHEEL_UP = EVENTBASE_INPUTEVENT+7;
+		static const int EVENT_MOUSEWHEEL_DOWN = EVENTBASE_INPUTEVENT+8;
 		
-		static const int EVENT_KEYDOWN = 13;
-		static const int EVENT_KEYUP = 14;
+		static const int EVENT_KEYDOWN = EVENTBASE_INPUTEVENT+13;
+		static const int EVENT_KEYUP = EVENTBASE_INPUTEVENT+14;
 		
-		static const int EVENT_JOYBUTTON_DOWN = 15;		
-		static const int EVENT_JOYBUTTON_UP = 16;
-		static const int EVENT_JOYAXIS_MOVED = 17;
-		static const int EVENT_JOYDEVICE_ATTACHED = 18;
-		static const int EVENT_JOYDEVICE_DETACHED = 19;
+		static const int EVENT_JOYBUTTON_DOWN = EVENTBASE_INPUTEVENT+15;
+		static const int EVENT_JOYBUTTON_UP = EVENTBASE_INPUTEVENT+16;
+		static const int EVENT_JOYAXIS_MOVED = EVENTBASE_INPUTEVENT+17;
+		static const int EVENT_JOYDEVICE_ATTACHED = EVENTBASE_INPUTEVENT+18;
+		static const int EVENT_JOYDEVICE_DETACHED = EVENTBASE_INPUTEVENT+19;
 		
-		static const int EVENT_TOUCHES_BEGAN = 20;
-		static const int EVENT_TOUCHES_MOVED = 21;
-		static const int EVENT_TOUCHES_ENDED =22;
+		static const int EVENT_TOUCHES_BEGAN = EVENTBASE_INPUTEVENT+20;
+		static const int EVENT_TOUCHES_MOVED = EVENTBASE_INPUTEVENT+21;
+		static const int EVENT_TOUCHES_ENDED = EVENTBASE_INPUTEVENT+22;
 		
 		
 		//@}

--- a/Core/Contents/Include/PolyServer.h
+++ b/Core/Contents/Include/PolyServer.h
@@ -41,7 +41,8 @@ namespace Polycode {
 		unsigned int dataSize;
 		unsigned short dataType;
 		
-		static const int EVENT_CLIENT_DATA = 0;
+		static const int EVENTBASE_SERVERCLIENTEVENT = 0x780;
+		static const int EVENT_CLIENT_DATA = EVENTBASE_SERVERCLIENTEVENT+0;
 	};
 	
 	class _PolyExport ServerClient : public EventDispatcher {
@@ -62,9 +63,11 @@ namespace Polycode {
 		
 		ServerClient *client;
 		
-		static const int EVENT_CLIENT_CONNECTED = 0;
-		static const int EVENT_CLIENT_DATA = 1;
-		static const int EVENT_CLIENT_DISCONNECTED = 2;		
+		static const int EVENTBASE_SERVEREVENT = 0x700;
+		static const int EVENT_CLIENT_CONNECTED = EVENTBASE_SERVEREVENT+0;
+		static const int EVENT_CLIENT_DATA = EVENTBASE_SERVEREVENT+1;
+		static const int EVENT_CLIENT_DISCONNECTED = EVENTBASE_SERVEREVENT+2;
+		// Notice also the SERVERCLIENTEVENT above, which starts with 0x780.
 	};
 
 	class _PolyExport Server : public Peer {

--- a/Core/Contents/Include/PolySocket.h
+++ b/Core/Contents/Include/PolySocket.h
@@ -94,8 +94,9 @@ namespace Polycode {
 		unsigned int dataSize;
 		Address fromAddress;
 		
-		static const int EVENT_ERROR = 0;
-		static const int EVENT_DATA_RECEIVED = 1;
+		static const int EVENTBASE_SOCKETEVENT = 0x500;
+		static const int EVENT_ERROR = EVENTBASE_SOCKETEVENT+0;
+		static const int EVENT_DATA_RECEIVED = EVENTBASE_SOCKETEVENT+1;
 	};
 	
 	

--- a/Core/Contents/Include/PolyWinCore.h
+++ b/Core/Contents/Include/PolyWinCore.h
@@ -119,7 +119,8 @@ namespace Polycode {
 		PolyKEY keyCode;
 		wchar_t unicodeChar;		
 		char mouseButton;	
-		static const int INPUT_EVENT = 0;
+		static const int EVENTBASE_PLATFORMEVENT = 0x300;
+		static const int INPUT_EVENT = EVENTBASE_PLATFORMEVENT+0;
 	};
 	
 	

--- a/Core/Contents/Include/PolyiPhoneCore.h
+++ b/Core/Contents/Include/PolyiPhoneCore.h
@@ -49,7 +49,8 @@ namespace Polycode {
 		
 		char mouseButton;
 		
-		static const int INPUT_EVENT = 0;
+		static const int EVENTBASE_PLATFORMEVENT = 0x300;
+		static const int INPUT_EVENT = EVENTBASE_PLATFORMEVENT+0;
 	};
 	
 	class _PolyExport IPhoneCore : public Core {

--- a/Modules/Contents/2DPhysics/Include/PolyPhysicsScreen.h
+++ b/Modules/Contents/2DPhysics/Include/PolyPhysicsScreen.h
@@ -95,21 +95,23 @@ class _PolyExport PhysicsScreenEvent : public Event {
 		* Friction strength of the impact
 		*/		
 		Number frictionStrength;	
-							
+			
+		static const int EVENTBASE_PHYSICSSCREENEVENT = 0x800;
+	
 		/**
 		* Event sent out when a collision begins
 		*/					
-		static const int EVENT_NEW_SHAPE_COLLISION = 0;
+		static const int EVENT_NEW_SHAPE_COLLISION = EVENTBASE_PHYSICSSCREENEVENT+0;
 		
 		/**
 		* Event sent out when a collision ends
 		*/							
-		static const int EVENT_END_SHAPE_COLLISION = 1;
+		static const int EVENT_END_SHAPE_COLLISION = EVENTBASE_PHYSICSSCREENEVENT+1;
 		
 		/**
 		* Event sent out when a collision begins
 		*/					
-		static const int EVENT_SOLVE_SHAPE_COLLISION = 3;
+		static const int EVENT_SOLVE_SHAPE_COLLISION = EVENTBASE_PHYSICSSCREENEVENT+3;
 
 		
 };		

--- a/Modules/Contents/3DPhysics/Include/PolyPhysicsScene.h
+++ b/Modules/Contents/3DPhysics/Include/PolyPhysicsScene.h
@@ -45,7 +45,8 @@ namespace Polycode {
 			PhysicsSceneEvent();
 			~PhysicsSceneEvent();
 			
-			static const int COLLISION_EVENT = 0;
+			static const int EVENTBASE_PHYSICSSCENEEVENT = 0x900;
+			static const int COLLISION_EVENT = EVENTBASE_PHYSICSSCENEEVENT+0;
 			
 			PhysicsSceneEntity *entityA;
 			PhysicsSceneEntity *entityB;

--- a/Modules/Contents/UI/Include/PolyUIEvent.h
+++ b/Modules/Contents/UI/Include/PolyUIEvent.h
@@ -31,11 +31,12 @@ namespace Polycode {
 			UIEvent();
 			~UIEvent();
 		
-			static const int CLICK_EVENT = 0;
-			static const int CLOSE_EVENT = 1;
-			static const int OK_EVENT = 2;
-			static const int CANCEL_EVENT = 3;
-			static const int CHANGE_EVENT = 4;
+			static const int EVENTBASE_UIEVENT = 0xA00;
+			static const int CLICK_EVENT = EVENTBASE_UIEVENT+0;
+			static const int CLOSE_EVENT = EVENTBASE_UIEVENT+1;
+			static const int OK_EVENT = EVENTBASE_UIEVENT+2;
+			static const int CANCEL_EVENT = EVENTBASE_UIEVENT+3;
+			static const int CHANGE_EVENT = EVENTBASE_UIEVENT+4;
 						
 		protected:
 		

--- a/Modules/Contents/UI/Include/PolyUITreeEvent.h
+++ b/Modules/Contents/UI/Include/PolyUITreeEvent.h
@@ -34,10 +34,11 @@ namespace Polycode {
 			UITreeEvent();
 			~UITreeEvent();
 		
-			static const int NEED_REFRESH_EVENT = 2000;
-			static const int SELECTED_EVENT = 2001;
-			static const int EXECUTED_EVENT = 2002;
-			static const int DRAG_START_EVENT = 2003;
+			static const int EVENTBASE_UITREEEVENT = 0xB00;
+			static const int NEED_REFRESH_EVENT = EVENTBASE_UITREEEVENT+0;
+			static const int SELECTED_EVENT = EVENTBASE_UITREEEVENT+1;
+			static const int EXECUTED_EVENT = EVENTBASE_UITREEEVENT+2;
+			static const int DRAG_START_EVENT = EVENTBASE_UITREEEVENT+3;
 			
 			UITree *selection;
 


### PR DESCRIPTION
...by adding a class-unique EVENTBASE_ constant to each class's event types. (The EVENTBASE_s are documented in PolyEvent.h.) Also make a small change to create_lua_library to support the EVENTBASE_ idiom.

Right now you can get these collisions by doing VERY basic tasks in the UI library, for example making a window and attaching a handler to CLOSE_EVENT will trigger on a non-UIEvent event if you click _anywhere_ in the window. The only way to avoid this currently is to do a string comparison in every event handler to double-check, which is not user friendly. Although collisions are in principle not possible to prevent completely, it is at least possible to ensure collisions never happen when using classes that ship with Polycode so we should do that.
