### PR TITLE
Make transparent screenshader screens possible again

### DIFF
--- a/Core/Contents/Include/PolyRenderer.h
+++ b/Core/Contents/Include/PolyRenderer.h
@@ -111,7 +111,7 @@ namespace Polycode {
 		virtual void setTexture(Texture *texture) = 0;		
 		virtual void enableBackfaceCulling(bool val) = 0;
 		
-		virtual void setClearColor(Number r, Number g, Number b);
+		virtual void setClearColor(Number r, Number g, Number b, Number a = 1.0);
 		virtual void setClearColor(Color color);
 		
 		virtual void setAmbientColor(Number r, Number g, Number b);

--- a/Core/Contents/Source/PolyGLRenderer.cpp
+++ b/Core/Contents/Source/PolyGLRenderer.cpp
@@ -551,8 +551,8 @@ void OpenGLRenderer::setPerspectiveMode() {
 
 void OpenGLRenderer::BeginRender() {
 	if(doClearBuffer) {
-		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 		glClearColor(clearColor.r, clearColor.g, clearColor.b, clearColor.a);
+		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 	}
 	glLoadIdentity();
 	currentTexture = NULL;

--- a/Core/Contents/Source/PolyRenderer.cpp
+++ b/Core/Contents/Source/PolyRenderer.cpp
@@ -385,12 +385,12 @@ void Renderer::setAmbientColor(Number r, Number g, Number b) {
 	ambientColor.setColor(r,g,b,1.0f);
 }
 
-void Renderer::setClearColor(Number r, Number g, Number b) {
-	clearColor.setColor(r,g,b,1.0f);	
+void Renderer::setClearColor(Number r, Number g, Number b, Number a) {
+	clearColor.setColor(r,g,b,a);	
 }
 
 void Renderer::setClearColor(Color color) {
-	setClearColor(color.r, color.g, color.b);
+	setClearColor(color.r, color.g, color.b, color.a);
 }
 
 void Renderer::setRenderMode(int newRenderMode) {


### PR DESCRIPTION
- Allow alpha in clear color set. 
  In the last few commits something changed, before the clearcolor was ignored for screens/scenes with PostFilters, afterward they started being applied. But! This is a problem because the current setClearColor doesn't allow alpha, so a see-through Screen with a post filter was not possible anymore. Add an alpha arg.
- Set clear color before-- not after-- clear
  Why on earth was it doing it this way before?
