### PR TITLE
Renamed variable linux because it is actually a macro in gnu++98

### DIFF
--- a/IDE/Contents/Source/PolycodeProjectManager.cpp
+++ b/IDE/Contents/Source/PolycodeProjectManager.cpp
@@ -137,7 +137,7 @@ void PolycodeProjectManager::createNewProject(String templateFolder, String proj
 	openProject(projectLocation+"/"+projectName+"/"+projectName+".polyproject");	
 }
 
-void PolycodeProjectManager::exportProject(PolycodeProject *project, String exportPath, bool macOS, bool windows, bool linux) {
+void PolycodeProjectManager::exportProject(PolycodeProject *project, String exportPath, bool macOS, bool windows, bool _linux) {
 
 	String polycodeBasePath = CoreServices::getInstance()->getCore()->getDefaultWorkingDirectory();
 


### PR DESCRIPTION
Fixes #167

This caused compilation to fail because linux is defined as 1 in the preprocessor for gnu++98, which is the default when compiling with g++.

This could also have been solved by chaging the c++ dialect to c++98 or something newer.
