### PR TITLE
Patch to compile Polycode in VS2012 for Win64

### DIFF
--- a/Core/Contents/Source/PolyWinCore.cpp
+++ b/Core/Contents/Source/PolyWinCore.cpp
@@ -1234,7 +1234,7 @@ void Win32Core::setCursor(int cursorType) {
 	}
 
 	SetCursor(cursor);
-	SetClassLong(hWnd, GCL_HCURSOR, (DWORD)cursor);
+	SetClassLongPtr(hWnd, GCLP_HCURSOR, (DWORD)cursor);
 }
 
 void  Win32Core::copyStringToClipboard(const String& str) {


### PR DESCRIPTION
- Change in PolyWinCore.cpp from SetClassLong to SetClassLongPtr for Win32
  and Win64 compatibility. See (1) and (2) for official Microsoft documentation on 
  SetClassLong and SetClassLongPtr, respectively.

(1) http://msdn.microsoft.com/en-us/library/windows/desktop/ms633588(v=vs.85).aspx
(2) http://msdn.microsoft.com/en-us/library/windows/desktop/ms633589(v=vs.85).aspx
