### PR TITLE
Replaced depreciated !png_check_sig

### DIFF
--- a/Core/Contents/Source/PolyImage.cpp
+++ b/Core/Contents/Source/PolyImage.cpp
@@ -792,7 +792,7 @@ bool Image::loadPNG(const String& fileName) {
 	
 	OSBasics::read(sig, 1, 8, infile);
 	
-	if (!png_check_sig((unsigned char *) sig, 8)) {
+	if (png_sig_cmp((unsigned char *) sig, 0, 8)) {
 		Logger::log("Error reading png signature\n");
 		OSBasics::close(infile);
 		return false;


### PR DESCRIPTION
Replaced depreciated !png_check_sig(sig, n) with png_sig_cmp(sig, 0, n)
