### PR TITLE
Fixes shift on windows, issue #85

### DIFF
--- a/Core/Contents/Source/PolyWinCore.cpp
+++ b/Core/Contents/Source/PolyWinCore.cpp
@@ -491,6 +491,7 @@ PolyKEY Win32Core::mapKey(LPARAM lParam, WPARAM wParam) {
 					} else {
 						wParam = VK_RSHIFT;
 					}
+					break;
 			}
 
 	return keyMap[(unsigned int)wParam];


### PR DESCRIPTION
See http://stackoverflow.com/questions/15966642/how-do-you-tell-lshift-apart-from-rshift-in-wm-keydown-events
