### PR TITLE
It's spelled 'frustum', not 'frustrum'

### DIFF
--- a/Core/Contents/Include/PolyCamera.h
+++ b/Core/Contents/Include/PolyCamera.h
@@ -45,22 +45,22 @@ namespace Polycode {
 			Camera(Scene *parentScene);
 			virtual ~Camera();
 			
-			void buildFrustrumPlanes();
+			void buildFrustumPlanes();
 			
 			/**
 			* Checks if the camera can see a sphere.
 			* @param pos Position of the sphere to check.
 			* @param fRadius Radius of the sphere.
-			* @return Returns true if the sphere is within the camera's frustrum, or false if it isn't.
+			* @return Returns true if the sphere is within the camera's frustum, or false if it isn't.
 			* @see canSee()
 			*/								
-			bool isSphereInFrustrum(Vector3 pos, Number fRadius);
+			bool isSphereInFrustum(Vector3 pos, Number fRadius);
 		
 			/**
 			* Checks if the camera can see an entity based on its bounding radius.
 			* @param entity Entity to check.
-			* @return Returns true if the entity's bounding radius is within the camera's frustrum, or false if it isn't.
-			* @see isSphereInFrustrum()
+			* @return Returns true if the entity's bounding radius is within the camera's frustum, or false if it isn't.
+			* @see isSphereInFrustum()
 			*/					
 			bool canSee(SceneEntity *entity);
 			

--- a/Core/Contents/Source/PolyCamera.cpp
+++ b/Core/Contents/Source/PolyCamera.cpp
@@ -74,7 +74,7 @@ Number Camera::getFOV() {
 }
 
 
-bool Camera::isSphereInFrustrum(Vector3 pos, Number fRadius) {
+bool Camera::isSphereInFrustum(Vector3 pos, Number fRadius) {
 	if(!frustumCulling)
 		return true;
     for( int i = 0; i < 6; ++i )
@@ -108,7 +108,7 @@ Number Camera::getOrthoSizeY() {
 }
 
 
-void Camera::buildFrustrumPlanes() {
+void Camera::buildFrustumPlanes() {
 
 	Matrix4 p; 
 	Matrix4 mv;
@@ -255,7 +255,7 @@ void Camera::buildFrustrumPlanes() {
 }
 
 bool Camera::canSee(SceneEntity *entity) {
-	return isSphereInFrustrum(entity->getPosition(), entity->getBBoxRadius());
+	return isSphereInFrustum(entity->getPosition(), entity->getBBoxRadius());
 }
 
 void Camera::setParentScene(Scene *parentScene) {

--- a/Core/Contents/Source/PolyScene.cpp
+++ b/Core/Contents/Source/PolyScene.cpp
@@ -235,7 +235,7 @@ void Scene::Render(Camera *targetCamera) {
 	}
 		
 	targetCamera->doCameraTransform();
-	targetCamera->buildFrustrumPlanes();
+	targetCamera->buildFrustumPlanes();
 	
 	CoreServices::getInstance()->getRenderer()->enableFog(fogEnabled);	
 	if(fogEnabled) {
@@ -247,7 +247,7 @@ void Scene::Render(Camera *targetCamera) {
 	
 	for(int i=0; i<entities.size();i++) {
 		if(entities[i]->getBBoxRadius() > 0) {
-			if(targetCamera->isSphereInFrustrum((entities[i]->getPosition()), entities[i]->getBBoxRadius()))
+			if(targetCamera->isSphereInFrustum((entities[i]->getPosition()), entities[i]->getBBoxRadius()))
 				entities[i]->transformAndRender();
 		} else {
 			entities[i]->transformAndRender();		
@@ -272,14 +272,14 @@ void Scene::RenderDepthOnly(Camera *targetCamera) {
 */	
 	targetCamera->rebuildTransformMatrix();	
 	targetCamera->doCameraTransform();	
-	targetCamera->buildFrustrumPlanes();
+	targetCamera->buildFrustumPlanes();
 	
 	CoreServices::getInstance()->getRenderer()->setTexture(NULL);
 	CoreServices::getInstance()->getRenderer()->enableShaders(false);
 	for(int i=0; i<entities.size();i++) {
 		if(entities[i]->castShadows) {
 		if(entities[i]->getBBoxRadius() > 0) {
-			if(targetCamera->isSphereInFrustrum((entities[i]->getPosition()), entities[i]->getBBoxRadius()))
+			if(targetCamera->isSphereInFrustum((entities[i]->getPosition()), entities[i]->getBBoxRadius()))
 				entities[i]->transformAndRender();
 		} else {
 			entities[i]->transformAndRender();		


### PR DESCRIPTION
Currently the code alternates the spellings "frustum" and "frustrum" depending on method, it's super confusing
