### PR TITLE
Uninitialized variables breaking sound on my machine

### DIFF
--- a/Core/Contents/Include/PolySound.h
+++ b/Core/Contents/Include/PolySound.h
@@ -63,6 +63,8 @@ namespace Polycode {
 		
 		void loadFile(String fileName);
 		
+		void reloadProperties();
+		
 		/**
 		* Play the sound once or in a loop.
 		* @param once If this is true, play it once, otherwise, loop.


### PR DESCRIPTION
"pitch", "volume", "reference distance" and "max distance" are all being initially set to the values of member variables of Sound -- BEFORE THOSE VARIABLES ARE ASSIGNED DEFAULT VALUES. pitch and volume are thereafter automatically assigned new values, reference distance and max distance are not. On some machines, notably mine, this can and does break all sound playback.

This patch: Gives these variables initializer values, consolidates some duplicate code, adds more error checks.
