### PR TITLE
Implemented OSBasics::fileExists

### DIFF
--- a/Core/Contents/Include/OSBasics.h
+++ b/Core/Contents/Include/OSBasics.h
@@ -72,6 +72,7 @@ class _PolyExport OSBasics : public PolyBase {
 	
 		static std::vector<OSFileEntry> parsePhysFSFolder(const Polycode::String& pathString, bool showHidden);
 		static std::vector<OSFileEntry> parseFolder(const Polycode::String& pathString, bool showHidden);
+		static bool fileExists(const Polycode::String& pathString);
 		static bool isFolder(const Polycode::String& pathString);
 		static void createFolder(const Polycode::String& pathString);
 		static void removeItem(const Polycode::String& pathString);

--- a/Core/Contents/Source/OSBasics.cpp
+++ b/Core/Contents/Source/OSBasics.cpp
@@ -28,6 +28,7 @@
 	#include <dirent.h>
 	#include <sys/types.h>
 	#include <sys/stat.h>
+	#include <unistd.h>
 #endif
 
 #include <vector>
@@ -256,6 +257,23 @@ vector<OSFileEntry> OSBasics::parsePhysFSFolder(const String& pathString, bool s
 	}
 	PHYSFS_freeList(rc);	
 	return returnVector;
+}
+
+bool OSBasics::fileExists(const Polycode::String& pathString) {
+	if(PHYSFS_exists(pathString.c_str())) {
+		return true;
+	}
+
+#ifdef _WINDOWS
+	WCHAR tmp[4096];
+	memset(tmp, 0, sizeof(WCHAR)*4096);
+	ctow(tmp, pathString.c_str());
+
+	DWORD dwAttrib = GetFileAttributes(tmp);
+    return (dwAttrib != 0xFFFFFFFF);
+#else
+	return (access(pathString.c_str(), F_OK) != -1);
+#endif
 }
 
 vector<OSFileEntry> OSBasics::parseFolder(const String& pathString, bool showHidden) {


### PR DESCRIPTION
This first checks if the file exists in physfs, and if not, it checks the actual filesystem using OS calls.
