### PR TITLE
 Custom Polycode Player Path and Copy Resource Path text fields in IDE settings

### DIFF
--- a/IDE/Contents/Include/PolycodeProject.h
+++ b/IDE/Contents/Include/PolycodeProject.h
@@ -42,6 +42,9 @@ class ProjectFontData {
 class ProjectData {
 	public:
 		String entryPoint;
+        String customPlayerPath;
+        String customResourceCopyPath;
+    
 		int defaultWidth;
 		int defaultHeight;
 		bool vSync;	

--- a/IDE/Contents/Include/PolycodeProjectEditor.h
+++ b/IDE/Contents/Include/PolycodeProjectEditor.h
@@ -89,6 +89,9 @@ class PolycodeProjectEditor : public PolycodeEditor {
 	UITextInput *entryPointInput;	
 	UIColorBox *bgColorBox;
 	
+	UITextInput *customPlayerPathInput;
+    UITextInput *copyResourcesPathInput;
+    
 	UIButton *addFontButton;
 	
 	PolycodeProject *associatedProject;

--- a/IDE/Contents/Source/PolycodeIDEApp.cpp
+++ b/IDE/Contents/Source/PolycodeIDEApp.cpp
@@ -344,7 +344,20 @@ void PolycodeIDEApp::doRunProject() {
 
 	String outPath = PolycodeToolLauncher::generateTempPath(projectManager->getActiveProject()) + ".polyapp";
 	PolycodeToolLauncher::buildProject(projectManager->getActiveProject(), outPath);
-	PolycodeToolLauncher::runPolyapp(outPath);
+    if(projectManager->getActiveProject()->data.customPlayerPath != "") {
+#ifdef _WINDOWS
+        // need windows solution
+#else
+        // Custom Poly Player
+        String command = "open";
+        String inFolder = projectManager->getActiveProject()->getRootFolder();
+        String args = projectManager->getActiveProject()->data.customPlayerPath;
+        String ret = CoreServices::getInstance()->getCore()->executeExternalCommand(command, args, inFolder);  
+#endif        
+    } else {
+        PolycodeToolLauncher::runPolyapp(outPath);  
+    }
+        
 }
 
 void PolycodeIDEApp::runProject() {

--- a/IDE/Contents/Source/PolycodeProject.cpp
+++ b/IDE/Contents/Source/PolycodeProject.cpp
@@ -47,6 +47,20 @@ bool PolycodeProject::loadProjectFromFile() {
 		configFile.root.addChild("entryPoint", "Source/Main.lua");
 	}
 	
+	if(configFile.root["customPlayerPath"]) {	
+		data.customPlayerPath = configFile.root["customPlayerPath"]->stringVal;
+	} else {
+		data.customPlayerPath = "";
+		configFile.root.addChild("customPlayerPath", "");
+	}
+    
+	if(configFile.root["customResourceCopyPath"]) {	
+		data.customResourceCopyPath = configFile.root["customResourceCopyPath"]->stringVal;
+	} else {
+		data.customResourceCopyPath = "";
+		configFile.root.addChild("customResourceCopyPath", "");
+	}
+    
 	if(configFile.root["defaultWidth"]) {	
 		data.defaultWidth = configFile.root["defaultWidth"]->intVal;
 	} else {
@@ -156,6 +170,12 @@ bool PolycodeProject::saveFile() {
 	configFile.root["textureFiltering"]->type = ObjectEntry::STRING_ENTRY;
 	configFile.root["textureFiltering"]->stringVal = data.filteringMode;
 	
+	configFile.root["customPlayerPath"]->stringVal = data.customPlayerPath;
+	configFile.root["customPlayerPath"]->type = ObjectEntry::STRING_ENTRY;	
+	configFile.root["customResourceCopyPath"]->stringVal = data.customResourceCopyPath;
+	configFile.root["customResourceCopyPath"]->type = ObjectEntry::STRING_ENTRY;	
+ 
+    
 	ObjectEntry *color = configFile.root["backgroundColor"];
 	
 	(*color)["red"]->NumberVal = data.backgroundColorR;

--- a/IDE/Contents/Source/PolycodeProjectEditor.cpp
+++ b/IDE/Contents/Source/PolycodeProjectEditor.cpp
@@ -273,6 +273,23 @@ PolycodeProjectEditor::PolycodeProjectEditor(PolycodeProjectManager *projectMana
 	entryPointInput->addEventListener(this, UIEvent::CHANGE_EVENT);
 	bgColorBox->addEventListener(this, UIEvent::CHANGE_EVENT);
 
+	customPlayerPathInput = new UITextInput(false, 450, 12);
+    mainSettingsWindow->addChild(customPlayerPathInput);    
+    customPlayerPathInput->setPosition(label2->getPosition().x, bgColorBox->getPosition().y+80);
+	label2 = new ScreenLabel(L"Custom Player Path", fontSize, fontName, Label::ANTIALIAS_FULL);
+	label2->setColor(1.0, 1.0, 1.0, 0.5);
+	mainSettingsWindow->addChild(label2);
+	label2->setPosition(padding, customPlayerPathInput->getPosition().y-18);
+    
+    
+    copyResourcesPathInput = new UITextInput(false, 450, 12);;
+    mainSettingsWindow->addChild(copyResourcesPathInput);    
+    copyResourcesPathInput->setPosition(label2->getPosition().x, customPlayerPathInput->getPosition().y+50);
+	label2 = new ScreenLabel(L"Custom Copy Resources Path", fontSize, fontName, Label::ANTIALIAS_FULL);
+	label2->setColor(1.0, 1.0, 1.0, 0.5);
+	mainSettingsWindow->addChild(label2);
+	label2->setPosition(padding, copyResourcesPathInput->getPosition().y-18);
+    
 	isLoading = false;
 }
 
@@ -327,6 +344,7 @@ void PolycodeProjectEditor::handleEvent(Event *event) {
 			fontEntries.push_back(newEntry);
 			refreshFontEntries();
 		}
+        
 		
 		globalFrame->assetBrowser->removeAllHandlersForListener(this);
 		dispatchEvent(new Event(), Event::CHANGE_EVENT);		
@@ -361,6 +379,10 @@ bool PolycodeProjectEditor::openFile(OSFileEntry filePath) {
 	defaultHeightInput->setText(String::IntToString(associatedProject->data.defaultHeight));
 	vSyncCheckBox->setChecked(associatedProject->data.vSync);
 	
+
+    customPlayerPathInput->setText(associatedProject->data.customPlayerPath);
+    copyResourcesPathInput->setText(associatedProject->data.customResourceCopyPath);    
+    
 	unsigned int aaMap[7] = {0,1,1,1,2,2,3};
 	aaLevelComboBox->setSelectedIndex(aaMap[associatedProject->data.aaLevel]);
 
@@ -373,6 +395,7 @@ bool PolycodeProjectEditor::openFile(OSFileEntry filePath) {
 	} else {
 		texFilteringComboBox->setSelectedIndex(1);	
 	}
+    
 
 	for(int i=0; i < associatedProject->data.fonts.size(); i++) {
 		ProjectFontData fontData = associatedProject->data.fonts[i];
@@ -422,6 +445,9 @@ void PolycodeProjectEditor::saveFile() {
 	associatedProject->data.frameRate = atoi(framerateInput->getText().c_str());
 	associatedProject->data.defaultWidth = atoi(defaultWidthInput->getText().c_str());
 	associatedProject->data.defaultHeight = atoi(defaultHeightInput->getText().c_str());	
+    
+	associatedProject->data.customPlayerPath = customPlayerPathInput->getText();
+    associatedProject->data.customResourceCopyPath = copyResourcesPathInput->getText();    
 	associatedProject->data.entryPoint = entryPointInput->getText();
 	
 	associatedProject->data.backgroundColorR = bgColorBox->getSelectedColor().r;

--- a/IDE/Contents/Source/PolycodeToolLauncher.cpp
+++ b/IDE/Contents/Source/PolycodeToolLauncher.cpp
@@ -89,11 +89,22 @@ void PolycodeToolLauncher::buildProject(PolycodeProject *project, String destina
 	String args =  "--config=\""+projectPath+"\" --out=\""+destinationPath+"\"";
 	String ret = CoreServices::getInstance()->getCore()->executeExternalCommand(command, args, targetFolder);
 #else
-	String command = polycodeBasePath+"/Standalone/Bin/polybuild";
-	String inFolder = projectBasePath; 
-	String args = "--config=\""+projectPath+"\" --out="+destinationPath;
-	String ret = CoreServices::getInstance()->getCore()->executeExternalCommand(command, args, inFolder);
-	PolycodeConsole::print(ret);
+	// Copy Resources to Custom location if defined    
+    if(project->data.customResourceCopyPath != "")
+    {
+        String command = "rsync";
+        String inFolder = projectBasePath; 
+        String args = "-r * \"../builds/doomlaser videogame draft.app/Contents/Resources/\"";
+        String ret = CoreServices::getInstance()->getCore()->executeExternalCommand(command, args, inFolder);  
+    }
+    else
+    {    
+        String command = polycodeBasePath+"/Standalone/Bin/polybuild";
+        String inFolder = projectBasePath; 
+        String args = "--config=\""+projectPath+"\" --out="+destinationPath;
+        String ret = CoreServices::getInstance()->getCore()->executeExternalCommand(command, args, inFolder);
+        PolycodeConsole::print(ret);
+    }
 #endif
 
 }


### PR DESCRIPTION
If these are defined, they will be used over the built-in PolyPlayer when you run from the IDE.

Works well if you want to use the IDE for content along with a custom Polycode derived C++ engine. No recompiles for content iteration.

Paths are relative to the project file.

Windows IDE support may need a look .
