### PR TITLE
Fixed entry point being packed twice.

### DIFF
--- a/Tools/Contents/polybuild/Source/polybuild.cpp
+++ b/Tools/Contents/polybuild/Source/polybuild.cpp
@@ -358,8 +358,6 @@ int main(int argc, char **argv) {
 	color->addChild("green", backgroundColorG);
 	color->addChild("blue", backgroundColorB);
 
-	addFileToZip(z, entryPoint, entryPoint, false);
-
 	if(configFile.root["fonts"]) {
 		runInfo.root.addChild(configFile.root["fonts"]);
 	}


### PR DESCRIPTION
Developer should pack entry point just like any other file. Plus it was weird having two identical file listings inside the .pak file.
