### PR TITLE
Restore continuous update option for UIHSlider, UIColorPicker

### DIFF
--- a/Core/Contents/Include/PolyScreenEntity.h
+++ b/Core/Contents/Include/PolyScreenEntity.h
@@ -275,7 +275,6 @@ class _PolyExport ScreenEntity : public Entity {
 		 */
 		ScreenEntity *getScreenEntityById(String id, bool recursive);
 
-
 		/**
 		 * Does the same as getEntitiesByID, but casts each result to ScreenEntity.
 		 *
@@ -325,13 +324,18 @@ class _PolyExport ScreenEntity : public Entity {
 
 		Number width;
 		Number height;
+		
+		/**
+		 * Get the drag status (true if currently being dragged) of the entity.
+		 */
+		bool isDragged();
 
 	protected:
 	
 		bool focusable;
 		bool focusChildren;
 		
-		bool isDragged;
+		bool dragged;
 		Number dragOffsetX;
 		Number dragOffsetY;
 		

--- a/Core/Contents/Source/PolyScreenEntity.cpp
+++ b/Core/Contents/Source/PolyScreenEntity.cpp
@@ -41,7 +41,7 @@ ScreenEntity::ScreenEntity() : Entity() {
 	backfaceCulled = false;
 	positionMode = POSITION_TOPLEFT;
 	mouseOver = false;
-	isDragged = false;
+	dragged = false;
 
 	dragOffsetX = 0;
 	dragOffsetY = 0;
@@ -190,13 +190,13 @@ bool ScreenEntity::isFocusable() const {
 }
 
 void ScreenEntity::startDrag(Number xOffset, Number yOffset) {
-	isDragged = true;
+	dragged = true;
 	dragOffsetX = xOffset;
 	dragOffsetY = yOffset;
 }
 
 void ScreenEntity::stopDrag() {
-	isDragged = false;
+	dragged = false;
 }
 
 ScreenEntity::~ScreenEntity() {
@@ -350,6 +350,10 @@ void ScreenEntity::setHitbox(Number width, Number height, Number left, Number to
 	hit.y = top;
 }
 
+bool ScreenEntity::isDragged() {
+	return dragged;
+}
+
 Matrix4 ScreenEntity::getScreenConcatenatedMatrix() {
 	Matrix4 retMatrix = transformMatrix;
 	if(positionMode == POSITION_TOPLEFT) {
@@ -366,8 +370,7 @@ Matrix4 ScreenEntity::getScreenConcatenatedMatrix() {
 
 MouseEventResult ScreenEntity::_onMouseMove(Number x, Number y, int timestamp, Vector2 parentAdjust) {
 
-	if(isDragged) {
-	
+	if(dragged) {
 		Vector3 localCoordinate = Vector3(x+(parentAdjust.x*2.0),y+(parentAdjust.y*2.0),0);				
 				
 		if(parentEntity) {

--- a/Modules/Contents/UI/Include/PolyUIColorBox.h
+++ b/Modules/Contents/UI/Include/PolyUIColorBox.h
@@ -56,8 +56,10 @@ namespace Polycode {
 			void Update();			
 			void onClose();
 			
-			void setPickerColor(Color newColor);
+			bool isContinuous();
+			void setContinuous(bool _continuous);
 			
+			void setPickerColor(Color newColor);
 			Color getSelectedColor();
 			
 		protected:
@@ -66,6 +68,7 @@ namespace Polycode {
 			Number lastHueSelectorPosition;
 			
 			bool suppressTextChangeEvent;
+			bool continuous;
 		
 			Color selectedColor;
 		

--- a/Modules/Contents/UI/Include/PolyUIHSlider.h
+++ b/Modules/Contents/UI/Include/PolyUIHSlider.h
@@ -42,6 +42,9 @@ namespace Polycode {
 			
 			void Resize(Number width, Number height);
 			
+			bool isContinuous();
+			void setContinuous(bool _continuous);
+			
 			void setSliderValue(Number val);
 			Number getSliderValue();			
 			
@@ -50,6 +53,7 @@ namespace Polycode {
 			Number gripPos;
 			
 			bool dragging;
+			bool continuous;
 			
 			Number bgHeight;
 			

--- a/Modules/Contents/UI/Source/PolyUIColorBox.cpp
+++ b/Modules/Contents/UI/Source/PolyUIColorBox.cpp
@@ -200,6 +200,14 @@ void UIColorPicker::rebuildFromTextInputs() {
 
 }
 
+bool UIColorPicker::isContinuous() {
+	return continuous;
+}
+void UIColorPicker::setContinuous(bool _continuous) {
+	continuous = _continuous;
+	alphaSlider->setContinuous(continuous);
+}
+
 void UIColorPicker::setPickerColor(Color newColor) {
 	currentS = newColor.getSaturation();
 	currentV = newColor.getValue();
@@ -398,6 +406,14 @@ void UIColorPicker::updateColorFromHueSelector() {
 }
 
 void UIColorPicker::Update() {	
+	if (continuous) {
+		if (mainSelector->isDragged())
+			updateColorFromMainSelector();
+		
+		if (hueSelector->isDragged())
+			updateColorFromHueSelector();
+	}
+	
 	UIWindow::Update();
 }
 

--- a/Modules/Contents/UI/Source/PolyUIHSlider.cpp
+++ b/Modules/Contents/UI/Source/PolyUIHSlider.cpp
@@ -94,6 +94,13 @@ void UIHSlider::setSliderValue(Number val) {
 	}
 }
 
+bool UIHSlider::isContinuous() {
+	return continuous;
+}
+void UIHSlider::setContinuous(bool _continuous) {
+	continuous = _continuous;
+}
+
 Number UIHSlider::getSliderValue() {
 	return sliderValue;
 }
@@ -157,5 +164,8 @@ void UIHSlider::Update() {
 	if(gripRect->getPosition().x != gripPos) {
 		gripPos = gripRect->getPosition().x;
 		sliderValue = startValue+((endValue - startValue) * (gripPos/sliderWidth));
+		if (continuous) {
+			dispatchEvent(new UIEvent(), UIEvent::CHANGE_EVENT);
+		}
 	}
 }


### PR DESCRIPTION
Change d857b25e2239 caused the color picker and slider to only send events on slider release, not continuously during drag. Sometimes (usually the case for me) continuous events are what you want. Patch adds setContinuous() option to slider and color picker (defaulting to off), restoring the lost functionality.
