### PR TITLE
Add Init() method to Renderer

### DIFF
--- a/Core/Contents/Include/PolyGLRenderer.h
+++ b/Core/Contents/Include/PolyGLRenderer.h
@@ -100,6 +100,8 @@ namespace Polycode {
 		
 		OpenGLRenderer();
 		~OpenGLRenderer();
+
+		bool Init();
 		
 		void Resize(int xRes, int yRes);
 		void BeginRender();
@@ -152,8 +154,6 @@ namespace Polycode {
 		void setScissorBox(Polycode::Rectangle box);		
 		
 		Vector3 projectRayFrom2DCoordinate(Number x, Number y);
-
-		void initOSSpecific();
 		
 		void setLineSize(Number lineSize);
 		
@@ -195,7 +195,7 @@ namespace Polycode {
 		void applyMaterial(Material *material,  ShaderBinding *localOptions, unsigned int shaderIndex);
 		
 	protected:
-
+		void initOSSpecific();
 		
 		Number nearPlane;
 		Number farPlane;

--- a/Core/Contents/Include/PolyRenderer.h
+++ b/Core/Contents/Include/PolyRenderer.h
@@ -90,6 +90,8 @@ namespace Polycode {
 		Renderer();
 		virtual ~Renderer();
 		
+		virtual bool Init();
+
 		virtual void Resize(int xRes, int yRes) = 0;
 		
 		virtual void BeginRender() = 0;
@@ -250,8 +252,6 @@ namespace Polycode {
 		
 		void *getDataPointerForName(const String &name);
 		void setRendererShaderParams(Shader *shader, ShaderBinding *binding);
-
-		virtual void initOSSpecific() {};
 		
 		void addShaderModule(PolycodeShaderModule *module);
 		
@@ -302,7 +302,8 @@ namespace Polycode {
 		
 		bool blendNormalAsPremultiplied;
 				
-	protected:	
+	protected:
+		virtual void initOSSpecific() {};
 	
 		bool scissorEnabled;
 		

--- a/Core/Contents/Source/PolyCocoaCore.mm
+++ b/Core/Contents/Source/PolyCocoaCore.mm
@@ -103,10 +103,11 @@ CocoaCore::CocoaCore(PolycodeView *view, int _xRes, int _yRes, bool fullScreen, 
 	context = nil;
 	
 	initTime = mach_absolute_time();					
-		
+
 	renderer = new OpenGLRenderer();
 	services->setRenderer(renderer);			
-	setVideoMode(xRes,yRes,fullScreen, vSync, aaLevel, anisotropyLevel);		
+	setVideoMode(xRes,yRes,fullScreen, vSync, aaLevel, anisotropyLevel);
+	renderer->Init();
 
 	CoreServices::getInstance()->installModule(new GLSLShaderModule());	
 

--- a/Core/Contents/Source/PolyGLRenderer.cpp
+++ b/Core/Contents/Source/PolyGLRenderer.cpp
@@ -89,14 +89,22 @@ OpenGLRenderer::OpenGLRenderer() : Renderer() {
 	nearPlane = 0.1f;
 	farPlane = 100.0f;
 	verticesToDraw = 0;
-	
-	glDisable(GL_SCISSOR_TEST);
+
 }
 
 void OpenGLRenderer::setClippingPlanes(Number nearPlane_, Number farPlane_) {
 	nearPlane = nearPlane_;
 	farPlane = farPlane_;
 	Resize(xRes,yRes);
+}
+
+bool OpenGLRenderer::Init() {
+	if(!Renderer::Init())
+		return false;
+
+	glDisable(GL_SCISSOR_TEST);
+
+	return true;
 }
 
 void OpenGLRenderer::initOSSpecific(){

--- a/Core/Contents/Source/PolyRenderer.cpp
+++ b/Core/Contents/Source/PolyRenderer.cpp
@@ -51,6 +51,12 @@ Renderer::Renderer() : clearColor(0.2f, 0.2f, 0.2f, 0.0), currentTexture(NULL), 
 Renderer::~Renderer() {
 }
 
+bool Renderer::Init() {
+	initOSSpecific();
+
+	return true;
+}
+
 void Renderer::enableShaders(bool flag) {
 	shadersEnabled = flag;
 }

--- a/Core/Contents/Source/PolySDLCore.cpp
+++ b/Core/Contents/Source/PolySDLCore.cpp
@@ -117,7 +117,7 @@ SDLCore::SDLCore(PolycodeView *view, int _xRes, int _yRes, bool fullScreen, bool
 	//  clipboard events and respond to them)
 	init_scrap();
 
-	((OpenGLRenderer*)renderer)->initOSSpecific();
+	((OpenGLRenderer*)renderer)->init();
 	CoreServices::getInstance()->installModule(new GLSLShaderModule());	
 }
 

--- a/Core/Contents/Source/PolyWinCore.cpp
+++ b/Core/Contents/Source/PolyWinCore.cpp
@@ -117,7 +117,7 @@ Win32Core::Win32Core(PolycodeViewBase *view, int _xRes, int _yRes, bool fullScre
 		Logger::log("Error initializing sockets!\n");
 	}
 
-	((OpenGLRenderer*)renderer)->initOSSpecific();
+	((OpenGLRenderer*)renderer)->init();
 
 	wglSwapIntervalEXT = (PFNWGLSWAPINTERVALEXTPROC) wglGetProcAddress("wglSwapIntervalEXT");
 	wglGetSwapIntervalEXT = (PFNWGLGETSWAPINTERVALEXTPROC) wglGetProcAddress("wglGetSwapIntervalEXT");


### PR DESCRIPTION
- moved the GL scissor disable to Init() because
  until setVideoMode() is called there may not be
  a valid GL context. This can happen, for example,
  in OS X if your PolyCocoaView isn't initialized
  from a nib and instead from code. Calling GL
  without a valid context can crash.
- Replaced calls to initOSSpecific() with calls to
  Init().
