### PR TITLE
Use given size as initial text input scroll container size

### DIFF
--- a/Modules/Contents/UI/Source/PolyUITextInput.cpp
+++ b/Modules/Contents/UI/Source/PolyUITextInput.cpp
@@ -172,7 +172,7 @@ UITextInput::UITextInput(bool multiLine, Number width, Number height) : UIElemen
 	
 	scrollContainer = NULL;
 	if(multiLine) {
-		scrollContainer = new UIScrollContainer(linesContainer, false, true, 200, 200);
+		scrollContainer = new UIScrollContainer(linesContainer, false, true, width, height);
 		scrollContainer->addEventListener(this, Event::CHANGE_EVENT);
 		addChild(scrollContainer);
 	} else {


### PR DESCRIPTION
- If we've got a size from the caller we might as well use
  it as the scroll container size. It's more generally
  usefull than arbitrary values. Otherwize a multi-line
  text input would always need to have it's size adjusted
  even though it's size was given in the ctor.
