### PR TITLE
Add the filename to some file loading error messages

### DIFF
--- a/Core/Contents/Source/PolyImage.cpp
+++ b/Core/Contents/Source/PolyImage.cpp
@@ -784,35 +784,35 @@ bool Image::loadPNG(const String& fileName) {
 	
 	infile = OSBasics::open(fileName.c_str(), "rb");
 	if (!infile) {
-		Logger::log("Error opening png file\n");	
+		Logger::log("Error opening png file (\"%s\")\n", fileName.c_str());
 		return false;
 	}
 	
 	OSBasics::read(sig, 1, 8, infile);
 	
 	if (!png_check_sig((unsigned char *) sig, 8)) {
-		Logger::log("Error reading png signature\n");
+		Logger::log("Error reading png signature (\"%s\")\n", fileName.c_str());
 		OSBasics::close(infile);
 		return false;
 	}
 
 	png_ptr = png_create_read_struct(PNG_LIBPNG_VER_STRING, NULL, NULL, NULL);
 	if (!png_ptr) {
-		Logger::log("Error creating png struct\n");
+		Logger::log("Error creating png struct (\"%s\")\n", fileName.c_str());
 		OSBasics::close(infile);
 		return false;    /* out of memory */
 	}
 	
 	info_ptr = png_create_info_struct(png_ptr);
 	if (!info_ptr) {
-		Logger::log("Error creating info struct\n");		
+		Logger::log("Error creating info struct (\"%s\")\n", fileName.c_str());
 		png_destroy_read_struct(&png_ptr, (png_infopp) NULL, (png_infopp) NULL);
 		OSBasics::close(infile);
 		return false;    /* out of memory */
 	}
 	
 	if (setjmp(png_jmpbuf(png_ptr))) {
-		Logger::log("Error setting jump thingie\n");
+		Logger::log("Error setting jump thingie (\"%s\")\n", fileName.c_str());
 		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 		OSBasics::close(infile);
 		return false;
@@ -856,13 +856,13 @@ bool Image::loadPNG(const String& fileName) {
 	
 	/* Allocate the image_data buffer. */
 	if ((image_data = (char *) malloc(rowbytes * height))==NULL) {
-		Logger::log("Error allocating image memory\n");		
+		Logger::log("Error allocating image memory (\"%s\")\n", fileName.c_str());
 		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 		return false;
 	}
 	
 	if ((row_pointers = (png_bytepp)malloc(height*sizeof(png_bytep))) == NULL) {
-		Logger::log("Error allocating image memory\n");
+		Logger::log("Error allocating image memory (\"%s\")\n", fileName.c_str());
 		png_destroy_read_struct(&png_ptr, &info_ptr, NULL);
 		free(image_data);
 		image_data = NULL;

--- a/Core/Contents/Source/PolyMaterialManager.cpp
+++ b/Core/Contents/Source/PolyMaterialManager.cpp
@@ -101,6 +101,11 @@ void MaterialManager::addShaderModule(PolycodeShaderModule *module) {
 }
 
 Texture *MaterialManager::createTextureFromFile(const String& fileName, bool clamp, bool createMipmaps) {
+	if(fileName.size() == 0) {
+		Logger::log("empty texture filename\n");
+		return NULL;
+	}
+
 	Texture *newTexture;
 	newTexture = getTextureByResourcePath(fileName);
 	if(newTexture) {
@@ -116,7 +121,7 @@ Texture *MaterialManager::createTextureFromFile(const String& fileName, bool cla
 		newTexture->setResourcePath(fileName);
 		CoreServices::getInstance()->getResourceManager()->addResource(newTexture);		
 	} else {
-		Logger::log("Error loading image, using default texture.\n");
+		Logger::log("Error loading image (\"%s\"), using default texture.\n", fileName.c_str());
 		delete image;		
 		newTexture = getTextureByResourcePath("default/default.png");
 		return newTexture;


### PR DESCRIPTION
- Helps to see what the problem is when upstream callers
  don't check errors.
- Add a check for an empty filename in
  MaterialManager::createTextureFromFile().
