### PR TITLE
Miscellaneous OpenGL error fixes

### DIFF
--- a/Core/Contents/Source/PolyGLRenderer.cpp
+++ b/Core/Contents/Source/PolyGLRenderer.cpp
@@ -497,7 +497,6 @@ void OpenGLRenderer::_setOrthoMode(Number orthoSizeX, Number orthoSizeY) {
 	
 	if(!orthoMode) {
 		glMatrixMode(GL_PROJECTION);
-		glPushMatrix();
 		glLoadIdentity();
 		glOrtho(-orthoSizeX*0.5,orthoSizeX*0.5,-orthoSizeY*0.5,orthoSizeY*0.5,-farPlane,farPlane);
 		orthoMode = true;
@@ -520,7 +519,6 @@ void OpenGLRenderer::setOrthoMode(Number xSize, Number ySize, bool centered) {
 	glDisable(GL_LIGHTING);
 	glMatrixMode(GL_PROJECTION);
 	glDisable(GL_CULL_FACE);
-	glPushMatrix();
 	glLoadIdentity();
 		
 	if(centered) {
@@ -548,7 +546,6 @@ void OpenGLRenderer::setPerspectiveMode() {
 		glEnable (GL_DEPTH_TEST);
 		glEnable(GL_CULL_FACE);
 		glMatrixMode( GL_PROJECTION );
-		glPopMatrix();
 		glMatrixMode( GL_MODELVIEW );
 		orthoMode = false;
 	}
@@ -583,7 +580,7 @@ void OpenGLRenderer::bindFrameBufferTextureDepth(Texture *texture) {
 	if(!texture)
 		return;
 	OpenGLTexture *glTexture = (OpenGLTexture*)texture;
-	glBindFramebufferEXT(GL_RENDERBUFFER_EXT, glTexture->getFrameBufferID());
+	glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, glTexture->getFrameBufferID());
 	glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);	
 }
 
@@ -598,7 +595,7 @@ void OpenGLRenderer::bindFrameBufferTexture(Texture *texture) {
 
 void OpenGLRenderer::unbindFramebuffers() {
 	glBindFramebufferEXT(GL_FRAMEBUFFER_EXT, 0);
-	glBindFramebufferEXT(GL_RENDERBUFFER_EXT, 0);
+	glBindRenderbufferEXT(GL_RENDERBUFFER_EXT, 0);
 }
 
 void OpenGLRenderer::createRenderTextures(Texture **colorBuffer, Texture **depthBuffer, int width, int height, bool floatingPointBuffer) {

--- a/Core/Contents/Source/PolyGLTexture.cpp
+++ b/Core/Contents/Source/PolyGLTexture.cpp
@@ -84,7 +84,7 @@ void OpenGLTexture::recreateFromImageData() {
 			}
 		
 			if(createMipmaps) {
-				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
 				glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
 				if(textureData) {
 					gluBuild2DMipmaps(GL_TEXTURE_2D, glTextureFormat, width, height, glTextureType, pixelType, textureData );


### PR DESCRIPTION
Bombed this macro all over Polycode

```
#define GLERR(x) for ( GLenum Error = glGetError( ); ( GL_NO_ERROR != Error ); \
Error = glGetError( ) ) {fprintf(stderr,"GLERR %s: %u\n", x, Error);}
```

Checked for places where Polycode was making OpenGL calls incorrectly. What I found:
- You can't use glBindFramebufferEXT with GL_RENDERBUFFER_EXT. You're supposed to use glBindRenderbufferEXT.
- You can't use GL_LINEAR_MIPMAP_LINEAR with GL_TEXTURE_MAG_FILTER. It's only defined for GL_TEXTURE_MIN_FILTER.
- There were glPushMatrix and glPopMatrix calls in the setOrthoMode and setPerspectiveMode functions?! There seemed to be an implication that every call to setOrthoMode would be balanced by a setPerspectiveMode call, but obviously that assumption doesn't hold and this behavior was causing the OpenGL matrix stack to overflow, like, constantly. I removed the calls and nothing broke. If there is indeed a place where you need this behavior, then there must be a better way to obtain it than this.
