### PR TITLE
reloadProgramsAndTextures breaks multipass screen shaders

### DIFF
--- a/Core/Contents/Source/PolyShader.cpp
+++ b/Core/Contents/Source/PolyShader.cpp
@@ -91,13 +91,7 @@ ShaderBinding::~ShaderBinding() {
 	}	
 	for(int i=0; i < renderTargetBindings.size(); i++) {
 		delete renderTargetBindings[i];
-	}	
-	for(int i=0; i < inTargetBindings.size(); i++) {
-		delete inTargetBindings[i];
-	}	
-	for(int i=0; i < outTargetBindings.size(); i++) {
-		delete outTargetBindings[i];
-	}	
+	}
 }
 
 unsigned int ShaderBinding::getNumLocalParams() {


### PR DESCRIPTION
If you have screenshaders with "in" and "out" parameters,

CoreServices::getInstance()->getMaterialManager()->reloadProgramsAndTextures();

BREAKS EVERYTHING. Attached is a partial fix.

PROBLEM I FIXED: If you call reloadProgramsAndTextures in this case, Polycode crashes.

PROBLEM I DIDN'T FIX: If you call reloadProgramsAndTextures in this case, your in/out textures do not get properly recreated. Instead, they will wind up just pulling in some random texture they latch on to. I tried adding:
    for(int m=0; m < materials.size(); m++) {
        materials[m]->recreateRenderTargets();
    }
to the end of MaterialManager::reloadPrograms in hopes that would fix it, but this change had no apparent effect so I did not check it in.
