### PR TITLE
new ScreenImage(""); // instantly crashes

### DIFF
--- a/Core/Contents/Source/PolyMaterialManager.cpp
+++ b/Core/Contents/Source/PolyMaterialManager.cpp
@@ -100,10 +100,12 @@ void MaterialManager::addShaderModule(PolycodeShaderModule *module) {
 	shaderModules.push_back(module);
 }
 
+#define DEFAULT_TEXTURE "default/default.png"
+
 Texture *MaterialManager::createTextureFromFile(const String& fileName, bool clamp, bool createMipmaps) {
 	if(fileName.size() == 0) {
-		Logger::log("empty texture filename\n");
-		return NULL;
+		Logger::log("empty texture filename, using default texture.\n");
+		return getTextureByResourcePath(DEFAULT_TEXTURE);
 	}
 
 	Texture *newTexture;
@@ -121,10 +123,8 @@ Texture *MaterialManager::createTextureFromFile(const String& fileName, bool cla
 		newTexture->setResourcePath(fileName);
 		CoreServices::getInstance()->getResourceManager()->addResource(newTexture);		
 	} else {
-		Logger::log("Error loading image (\"%s\"), using default texture.\n", fileName.c_str());
-		delete image;		
-		newTexture = getTextureByResourcePath("default/default.png");
-		return newTexture;
+		Logger::log("Error loading image (\"%s\"), using default texture.\n", fileName.c_str());		
+		newTexture = getTextureByResourcePath(DEFAULT_TEXTURE);
 	}
 		
 	delete image;


### PR DESCRIPTION
Currently if you pass MaterialManager::createTextureFromFile an incorrect file path it returns the default texture, and if you pass it an empty string it special-case returns NULL. Other Polycode classes do not anticipate this inconsistency and can crash when this occurs.
