### PR TITLE
[Linux] - remove destination file or directory before copying to it.

### DIFF
--- a/Core/Contents/Source/PolySDLCore.cpp
+++ b/Core/Contents/Source/PolySDLCore.cpp
@@ -443,11 +443,10 @@ void SDLCore::createFolder(const String& folderPath) {
 }
 
 void SDLCore::copyDiskItem(const String& itemPath, const String& destItemPath) {
-    removeDiskItem(destItemPath);
     int childExitStatus;
     pid_t pid = fork();
     if (pid == 0) {
-        execl("/bin/cp", "/bin/cp", "-R", itemPath.c_str(), destItemPath.c_str(), (char *)0);
+        execl("/bin/cp", "/bin/cp", "-RT", itemPath.c_str(), destItemPath.c_str(), (char *)0);
     } else {
         pid_t ws = waitpid( pid, &childExitStatus, 0);
     }


### PR DESCRIPTION
The current implementation in SDLCore::copyDiskItem can have unexpected behaviour when dealing with directories. I don't know how to concisely explain it...

'cp -R src/Dir dst/Dir' will make dst/Dir a copy of src/Dir (as probably intended); however if dst/Dir exists it will copy src/Dir into the directory dst/Dir which results in dst/Dir/Dir being a copy of src/Dir (probably not intended). This can be seen in the IDE by publishing to the same directory twice in a row and will leave you with something like 'exportPath/Linux/Linux'.

On many distros you can change the command to 'cp -RT src/Dir dst/Dir' and even if dst/Dir exists it will result in dst/Dir being a copy of src/Dir. However, I don't think the '-T ' switch is a Linux standard and have no clue how to find out.

Instead I use removeDiskItem on the destItemPath before doing the cp. This means copyDiskItem("src/file", "Dir") will now remove Dir and replace it with a copy of src/file. To copy src/file into Dir you would need to do copyDiskItem("src/file", "Dir/file"). I suspect this is expected/intended behaviour of copyDiskItem across Win and Mac as well; if not, a different fix is necessary.
