### PR TITLE
[Linux] Implemented setCursor in PolySDLCore.

### DIFF
--- a/Core/Contents/Source/PolySDLCore.cpp
+++ b/Core/Contents/Source/PolySDLCore.cpp
@@ -931,6 +931,7 @@ void set_cursor(int cursorType) {
 }
 
 void free_cursors() {
+	XUndefineCursor(SDL_Display, SDL_Window);
 	for(int i = 0; i < CURSOR_COUNT; i++) {
 		if(defined_cursors[i]) {
 			XFreeCursor(SDL_Display, defined_cursors[i]);


### PR DESCRIPTION
This commit uses X11 to implement setCursor for PolySDLCore. The cursors themselves might need to be changed since I don't know what they look like on Win/Mac...
