### PR TITLE
Extend the view frustrum

### DIFF
--- a/Core/Contents/Source/PolyGLRenderer.cpp
+++ b/Core/Contents/Source/PolyGLRenderer.cpp
@@ -87,7 +87,7 @@ using namespace Polycode;
 OpenGLRenderer::OpenGLRenderer() : Renderer() {
 
 	nearPlane = 0.1f;
-	farPlane = 100.0f;
+	farPlane = 1000.0f;
 	verticesToDraw = 0;
 
 }


### PR DESCRIPTION
1000.0f gives a much better view frustrum while still maintaining depth buffer precision.
