### PR TITLE
Fixed bug where Cone ScenePrimitive would be missing one or more faces.

### DIFF
--- a/Core/Contents/Source/PolyMesh.cpp
+++ b/Core/Contents/Source/PolyMesh.cpp
@@ -606,13 +606,12 @@ namespace Polycode {
 		setMeshType(Mesh::TRI_MESH);
 		Number lastx = -1;
 		Number lastz = -1;		
-		bool secondPassOrGreater = false;
 		for (int i=0 ; i < numSegments+1; i++) {
 			Number pos = ((PI*2.0)/((Number)numSegments)) * i;
 			Number x = sinf(pos) * radius;
 			Number z = cosf(pos) * radius;
 			
-			if(secondPassOrGreater) {
+			if(i > 0) { // ie only construct faces one we have vertexes from i-1 to use.
 				Polygon *polygon = new Polygon();
 				polygon->addVertex(lastx,0,lastz,0,0);				
 				polygon->addVertex(x,0,z, 1, 0);
@@ -630,7 +629,6 @@ namespace Polycode {
 			}
 			lastx = x;
 			lastz = z;	
-			secondPassOrGreater = true;
 		/*
 			Polygon *polygon = new Polygon();
 			polygon->addVertex(w,0,h, 1, 1);


### PR DESCRIPTION
Bug occurred when creating cone with radius 1 or greater eg:
new ScenePrimitive(ScenePrimitive::TYPE_CONE, 3.5,2.0, 12);

Original algorithm assumes that lastx > -1 for all iterations
except first pass of vertex calcuations.  In fact, lastx has a lower bound
of -1*radius, thus will be <= -1 often when radius is -1 or greater.

In some examples, I needed to adjust cone->setYaw(90) so that the missing
faces were presented to the camera (however I have included only the minimal change for this pull request, so there are no changes to example project code).
