### PR TITLE
Added setBoolValue and getBoolValue so param can be evaluated when neede...

### DIFF
--- a/Core/Contents/Include/PolyConfig.h
+++ b/Core/Contents/Include/PolyConfig.h
@@ -91,6 +91,21 @@ namespace Polycode {
 		* @param key String key of the value.
 		*/						
 		const String& getStringValue(const String& configNamespace, const String& key);
+
+		/**
+		* Sets a string value that represents boolean (true|false) key.
+		* @param configNamespace Namespace to set value in.
+		* @param key String key of the value.
+		* @param value The string value to save.
+		*/
+		void setBoolValue(const String& configNamespace, const String& key, bool value);
+
+		/**
+		* Returns a boolean value by eveluating a string key (true|1 = true).
+		* @param configNamespace Namespace to get the value from.
+		* @param key String key of the value.
+		*/
+		bool getBoolValue(const String& configNamespace, const String& key);
 		
 	private:
 		

--- a/Core/Contents/Source/PolyConfig.cpp
+++ b/Core/Contents/Source/PolyConfig.cpp
@@ -112,7 +112,6 @@ void Config::setNumericValue(const String& configNamespace, const String& key, N
 	getEntry(configNamespace, key)->isString = false;		
 }
 
-
 Number Config::getNumericValue(const String& configNamespace, const String& key) {
 	return getEntry(configNamespace, key)->numVal;
 }
@@ -121,4 +120,16 @@ const String& Config::getStringValue(const String& configNamespace, const String
 	return getEntry(configNamespace, key)->stringVal;	
 }
 
+void Config::setBoolValue(const String& configNamespace, const String& key, bool value) {
+	getEntry(configNamespace, key)->stringVal = (!value ? "false" : "true");
+	getEntry(configNamespace, key)->isString = true;
+}
 
+bool Config::getBoolValue(const String& configNamespace, const String& key) {
+	const String& str = getEntry(configNamespace, key)->stringVal;
+
+	if (str == "true" || str == "1") {
+		return true;
+	}		
+	return false;
+}


### PR DESCRIPTION
Just a simple boolean addition to config parsing so one doesn't have to validate integers inline when bool is expected by method. 

When using getBoolValue;
Param is parsed as a string and then checked if it contains true or 1, if it does it will return as true otherwise false. Reason for 1 is that sometimes user may manually edit a config file and instead of true they may set it to 1 and expect same result. As both is perfectly valid, function evaluates both possibilities. 

setBoolValue;
Simply sets true or false (as string) to desired param.  

NOTE: This could easily be done at the top layer using integer and evaluating, but that produces inline if's/extra vars and somewhat ugly code, imho it's cleaner to have this at the baseline. 
