### PR TITLE
Fix for crash with SceneParticleEmitter::setParticleTexture

### DIFF
--- a/Core/Contents/Include/PolyParticleEmitter.h
+++ b/Core/Contents/Include/PolyParticleEmitter.h
@@ -230,7 +230,7 @@ namespace Polycode {
 			
 			Texture *getParticleTexture() const;
 			
-			void setParticleTexture(Texture *texture);
+			virtual void setParticleTexture(Texture *texture) = 0;
 		
 			Vector3 emitterRadius;
 					
@@ -309,6 +309,8 @@ namespace Polycode {
 		
 		void dispatchTriggerCompleteEvent();
 		
+		virtual void setParticleTexture(Texture *texture);
+
 			/**
 			* Continuous emitter setting.
 			*/ 																													
@@ -334,7 +336,8 @@ namespace Polycode {
 		
 		virtual Entity *Clone(bool deepClone, bool ignoreEditorOnly) const;
 		virtual void applyClone(Entity *clone, bool deepClone, bool ignoreEditorOnly) const;
-		
+		virtual void setParticleTexture(Texture *texture);
+
 		/**
 		* Returns the emitter (helper method for LUA).
 		*/ 		

--- a/Core/Contents/Source/PolyParticleEmitter.cpp
+++ b/Core/Contents/Source/PolyParticleEmitter.cpp
@@ -26,6 +26,7 @@
 #include "PolyPerlin.h"
 #include "PolyResource.h"
 #include "PolyScene.h"
+#include "PolySceneMesh.h"
 #include "PolyScreen.h"
 #include "PolyTimer.h"
 #include "PolyMaterialManager.h"
@@ -230,13 +231,24 @@ Texture *ParticleEmitter::getParticleTexture() const {
 	return particleTexture;
 }
 
-void ParticleEmitter::setParticleTexture(Texture *texture) {
-	particleTexture = texture;
+template<typename T>
+inline void setParticlesTexture(std::vector<Particle*>& particles, Texture* texture) {
 	for(int i=0; i < particles.size(); i++) {
-		((ScreenMesh*)particles[i]->particleBody)->setTexture(particleTexture);
+		Particle* particle = particles[i];
+		T* particleSceneMesh = (T*)particle->particleBody;
+		particleSceneMesh->setTexture(texture);
 	}
 }
-			
+
+void ScreenParticleEmitter::setParticleTexture(Texture *texture) {
+	particleTexture = texture;
+	setParticlesTexture<ScreenMesh>(particles, texture);
+}
+void SceneParticleEmitter::setParticleTexture(Texture *texture) {
+	particleTexture = texture;
+	setParticlesTexture<SceneMesh>(particles, texture);
+}
+
 void ParticleEmitter::createParticles() {
 	
 	if(isScreenEmitter)


### PR DESCRIPTION
Was getting a crash when trying to setParticleTexture on a SceneParticleEmitter. setParticleTexture was indiscriminately casting particleBody to ScreenMesh, and never SceneMesh. 
