### PR TITLE
Added support for Polycode being able to use single-precision

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,6 +16,10 @@ ENDIF(NOT CMAKE_BUILD_TYPE)
 #    SET(build_player OFF)
 #ENDIF()
 
+IF(NUMBER_IS_SINGLE)
+add_definitions(-DPOLYCODE_NUMBER_IS_SINGLE)
+ENDIF()
+
 # Options for what components to build
 #OPTION(POLYCODE_BUILD_SHARED "Build Polycode shared libraries" OFF)
 #OPTION(POLYCODE_BUILD_STATIC "Build Polycode static libraries" ON)

--- a/Core/Contents/Include/PolyColor.h
+++ b/Core/Contents/Include/PolyColor.h
@@ -41,8 +41,13 @@ namespace Polycode {
 			* @param b Blue value 0-1
 			* @param a Alpha value 0-1									
 			*/														
-			Color(Number r,Number g, Number b, Number a);
-			
+			Color(float r,float g,float b,float a);
+
+			/**
+			* @copydoc Color::Color(float,float,float,float)
+			*/
+			Color(double r,double g,double b,double a);
+
 			/**
 			* Default constructor.
 			*/						

--- a/Core/Contents/Include/PolyCore.h
+++ b/Core/Contents/Include/PolyCore.h
@@ -295,9 +295,9 @@ namespace Polycode {
 		
 		/**
 		* Returns the total ticks elapsed since launch.
-		* @return Time elapsed since launch in floating point microseconds.
+		* @return Time elapsed since launch in floating point seconds.
 		*/		
-		Number getTicksFloat();
+		double getTicksFloat();
 		
 		void setUserPointer(void *ptr) { userPointer = ptr; }
 		void *getUserPointer() { return userPointer; }

--- a/Core/Contents/Include/PolyGlobals.h
+++ b/Core/Contents/Include/PolyGlobals.h
@@ -78,7 +78,11 @@ THE SOFTWARE.
 	#define PLATFORM PLATFORM_UNIX
 #endif
 
+#ifdef POLYCODE_NUMBER_IS_SINGLE
+typedef float Number;
+#else
 typedef double Number;
+#endif
 
 #define RANDOM_NUMBER ((Number)rand()/(Number)RAND_MAX)
 

--- a/Core/Contents/Include/PolyScreenSprite.h
+++ b/Core/Contents/Include/PolyScreenSprite.h
@@ -143,7 +143,7 @@ class _PolyExport ScreenSprite : public ScreenShape
 		Number spriteHeight;
 			
 		bool playingOnce;
-		Number lastTick;
+		double lastTick;
 		
 		ScreenSpriteResourceEntry *resourceEntry;
 		

--- a/Core/Contents/Source/PolyColor.cpp
+++ b/Core/Contents/Source/PolyColor.cpp
@@ -29,7 +29,11 @@ Color::Color() : r(1),g(1),b(1),a(1){
 
 }
 
-Color::Color(Number r,Number g, Number b, Number a) {
+Color::Color(float r,float g, float b, float a) {
+	setColor(r,g,b,a);
+}
+
+Color::Color(double r,double g, double b, double a) {
 	setColor(r,g,b,a);
 }
 

--- a/Core/Contents/Source/PolyCore.cpp
+++ b/Core/Contents/Source/PolyCore.cpp
@@ -129,8 +129,8 @@ namespace Polycode {
 		return ((Number)elapsed)/1000.0f;
 	}
 	
-	Number Core::getTicksFloat() {
-		return ((Number)getTicks())/1000.0f;		
+	double Core::getTicksFloat() {
+		return getTicks()/1000.0d;
 	}
 		
 	void Core::createThread(Threaded *target) {

--- a/Core/Contents/Source/PolyGLRenderer.cpp
+++ b/Core/Contents/Source/PolyGLRenderer.cpp
@@ -85,6 +85,13 @@ PFNGLGENERATEMIPMAPEXTPROC glGenerateMipmapEXT;
 #endif
 using namespace Polycode;
 
+inline void polycodeGLGetNumberv( GLenum pname, GLdouble *params ) {
+	glGetDoublev(pname, params);
+}
+inline void polycodeGLGetNumberv( GLenum pname, GLfloat *params ) {
+	glGetFloatv(pname, params);
+}
+
 OpenGLRenderer::OpenGLRenderer() : Renderer() {
 
 	nearPlane = 0.1f;
@@ -230,7 +237,7 @@ void OpenGLRenderer::resetViewport() {
 	glViewport(0, 0, viewportWidth, viewportHeight);
 	glScissor(0, 0,  viewportWidth, viewportHeight);
 	glMatrixMode(GL_MODELVIEW);	
-	glGetDoublev( GL_PROJECTION_MATRIX, sceneProjectionMatrix);
+	polycodeGLGetNumberv(GL_PROJECTION_MATRIX, sceneProjectionMatrix);
 }
 
 Vector3 OpenGLRenderer::Unproject(Number x, Number y) {
@@ -239,10 +246,10 @@ Vector3 OpenGLRenderer::Unproject(Number x, Number y) {
 	GLdouble cx, cy, cz;
 	
 	GLdouble mv[16];
-	glGetDoublev( GL_MODELVIEW_MATRIX, mv );
+	polycodeGLGetNumberv( GL_MODELVIEW_MATRIX, mv );
 	
 	GLdouble proj[16];
-	glGetDoublev( GL_PROJECTION_MATRIX, proj );
+	polycodeGLGetNumberv( GL_PROJECTION_MATRIX, proj );
 	
 	GLint vp[4];
 	glGetIntegerv( GL_VIEWPORT, vp );
@@ -306,13 +313,29 @@ void OpenGLRenderer::enableDepthTest(bool val) {
 		glDisable(GL_DEPTH_TEST);	
 }
 
+inline void loadMatrixNumber(const GLfloat* m) {
+	glLoadMatrixf(m);
+}
+
+inline void loadMatrixNumber(const GLdouble* m) {
+	glLoadMatrixd(m);
+}
+
+inline void multMatrixNumber(const GLfloat* m) {
+	glMultMatrixf(m);
+}
+
+inline void multMatrixNumber(const GLdouble* m) {
+	glMultMatrixd(m);
+}
+
 void OpenGLRenderer::setModelviewMatrix(Matrix4 m) {
-	glLoadMatrixd(m.ml);
+	loadMatrixNumber(m.ml);
 }
 
 void OpenGLRenderer::multModelviewMatrix(Matrix4 m) {
 //	glMatrixMode(GL_MODELVIEW);
-	glMultMatrixd(m.ml);
+	multMatrixNumber(m.ml);
 }
 
 void OpenGLRenderer::enableLighting(bool enable) {
@@ -465,13 +488,13 @@ void OpenGLRenderer::setBlendingMode(int blendingMode) {
 
 Matrix4 OpenGLRenderer::getProjectionMatrix() {
 	Number m[16];
-	glGetDoublev( GL_PROJECTION_MATRIX, m);
+	polycodeGLGetNumberv( GL_PROJECTION_MATRIX, m);
 	return Matrix4(m);
 }
 
 Matrix4 OpenGLRenderer::getModelviewMatrix() {
 	Number m[16];
-    glGetDoublev( GL_MODELVIEW_MATRIX, m);
+	polycodeGLGetNumberv( GL_MODELVIEW_MATRIX, m);
 	return Matrix4(m);
 }
 
@@ -519,7 +542,7 @@ void OpenGLRenderer::_setOrthoMode(Number orthoSizeX, Number orthoSizeY) {
 		glOrtho(-orthoSizeX*0.5,orthoSizeX*0.5,-orthoSizeY*0.5,orthoSizeY*0.5,-farPlane,farPlane);
 		orthoMode = true;
 	}
-	glGetDoublev( GL_PROJECTION_MATRIX, sceneProjectionMatrixOrtho);
+	polycodeGLGetNumberv( GL_PROJECTION_MATRIX, sceneProjectionMatrixOrtho);
 		
 	glMatrixMode(GL_MODELVIEW);	
 	glLoadIdentity();	
@@ -569,7 +592,7 @@ void OpenGLRenderer::setPerspectiveMode() {
 	}
 	glLoadIdentity();
 	
-	glGetDoublev( GL_PROJECTION_MATRIX, sceneProjectionMatrix);
+	polycodeGLGetNumberv( GL_PROJECTION_MATRIX, sceneProjectionMatrix);
 	currentTexture = NULL;
 }
 

--- a/Core/Contents/Source/PolyMaterialManager.cpp
+++ b/Core/Contents/Source/PolyMaterialManager.cpp
@@ -511,7 +511,7 @@ Material *MaterialManager::materialFromXMLNode(TiXmlNode *node) {
 										{
 											std::vector<String> values = pvalue.split(" ");
 											if(values.size() == 3) {
-												param->setVector3(Vector3(atof(values[0].c_str()), atof(values[1].c_str()), atof(values[2].c_str())));
+												param->setVector3(Vector3((Number)atof(values[0].c_str()), (Number)atof(values[1].c_str()), (Number)atof(values[2].c_str())));
 											} else {
 												printf("Material parameter error: A Vector3 must have 3 values (%d provided)!\n", (int)values.size());
 											}
@@ -521,7 +521,7 @@ Material *MaterialManager::materialFromXMLNode(TiXmlNode *node) {
 										{
 											std::vector<String> values = pvalue.split(" ");
 											if(values.size() == 4) {
-												param->setColor(Color(atof(values[0].c_str()), atof(values[1].c_str()), atof(values[2].c_str()), atof(values[3].c_str())));
+												param->setColor(Color((Number)atof(values[0].c_str()), (Number)atof(values[1].c_str()), (Number)atof(values[2].c_str()), (Number)atof(values[3].c_str())));
 											} else {
 												printf("Material parameter error: A Vector3 must have 3 values (%d provided)!\n", (int)values.size());
 											}

--- a/Core/Contents/Source/PolyMesh.cpp
+++ b/Core/Contents/Source/PolyMesh.cpp
@@ -369,9 +369,9 @@ namespace Polycode {
 		
 		for(int i=0; i < polygons.size(); i++) {
 			for(int j=0; j < polygons[i]->getVertexCount(); j++) {				
-				retVec.x = max(retVec.x,fabs(polygons[i]->getVertex(j)->x));
-				retVec.y = max(retVec.y,fabs(polygons[i]->getVertex(j)->y));
-				retVec.z = max(retVec.z,fabs(polygons[i]->getVertex(j)->z));							
+				retVec.x = max(retVec.x,(Number)fabs(polygons[i]->getVertex(j)->x));
+				retVec.y = max(retVec.y,(Number)fabs(polygons[i]->getVertex(j)->y));
+				retVec.z = max(retVec.z,(Number)fabs(polygons[i]->getVertex(j)->z));
 				
 			}
 		}

--- a/Core/Contents/Source/PolyRenderer.cpp
+++ b/Core/Contents/Source/PolyRenderer.cpp
@@ -25,7 +25,7 @@
 
 using namespace Polycode;
 
-Renderer::Renderer() : clearColor(0.2f, 0.2f, 0.2f, 0.0), currentTexture(NULL), renderMode(0), lightingEnabled(false), orthoMode(false), xRes(0), yRes(0) {
+Renderer::Renderer() : clearColor(0.2, 0.2, 0.2, 0.0), currentTexture(NULL), renderMode(0), lightingEnabled(false), orthoMode(false), xRes(0), yRes(0) {
 	anisotropy = 0;
 	textureFilteringMode = TEX_FILTERING_LINEAR;
 	currentMaterial = NULL;

--- a/Core/Contents/Source/PolyScreenSprite.cpp
+++ b/Core/Contents/Source/PolyScreenSprite.cpp
@@ -347,9 +347,9 @@ void ScreenSprite::Update() {
 	if(!currentAnimation)
 		return;
 	
-	Number newTick = CoreServices::getInstance()->getCore()->getTicksFloat();
+	double newTick = CoreServices::getInstance()->getCore()->getTicksFloat();
 	
-	Number elapsed = newTick - lastTick;
+	Number elapsed = Number(newTick - lastTick);
 	
 	if(paused)
 		return;

--- a/Core/Contents/Source/PolyString.cpp
+++ b/Core/Contents/Source/PolyString.cpp
@@ -70,7 +70,7 @@ size_t String::getDataSizeWithEncoding(int encoding) const {
 			return contents.size();
 		}
 		default:
-			return NULL;
+			return 0;
 	}
 }
 const char *String::getDataWithEncoding(int encoding) const {

--- a/Core/Contents/Source/PolyWinCore.cpp
+++ b/Core/Contents/Source/PolyWinCore.cpp
@@ -168,7 +168,7 @@ void Win32Core::warpCursor(int x, int y) {
 unsigned int Win32Core::getTicks() {
 	LARGE_INTEGER li;
 	QueryPerformanceCounter(&li);
-	return unsigned int(li.QuadPart / pcFreq);
+	return (unsigned int)(li.QuadPart / pcFreq);
 }
 
 void Win32Core::Render() {

--- a/Modules/Contents/UI/Source/PolyUIColorBox.cpp
+++ b/Modules/Contents/UI/Source/PolyUIColorBox.cpp
@@ -251,10 +251,10 @@ void UIColorPicker::updateSelectedColor(bool updateTextFields, bool updateHue, b
 	hueCol.setColorHSV(currentH, 1.0, 1.0);
 	hueCol.a = colorAlpha;
 
-	mainColorRect->getMesh()->getPolygon(0)->getVertex(0)->vertexColor = Color(1.0,1.0,1.0,colorAlpha);
+	mainColorRect->getMesh()->getPolygon(0)->getVertex(0)->vertexColor = Color((Number)1,(Number)1,(Number)1,colorAlpha);
 	mainColorRect->getMesh()->getPolygon(0)->getVertex(1)->vertexColor = hueCol;
-	mainColorRect->getMesh()->getPolygon(0)->getVertex(2)->vertexColor = Color(0.0,0.0,0.0,colorAlpha);
-	mainColorRect->getMesh()->getPolygon(0)->getVertex(3)->vertexColor = Color(0.0,0.0,0.0,colorAlpha);	
+	mainColorRect->getMesh()->getPolygon(0)->getVertex(2)->vertexColor = Color((Number)0,(Number)0,(Number)0,colorAlpha);
+	mainColorRect->getMesh()->getPolygon(0)->getVertex(3)->vertexColor = Color((Number)0,(Number)0,(Number)0,colorAlpha);
 	mainColorRect->getMesh()->arrayDirtyMap[RenderDataArray::COLOR_DATA_ARRAY] = true;				
 	
 		


### PR DESCRIPTION
Users can compile Number to be float, rather than double, by setting -DNUMBER_IS_SINGLE=true when running CMake. NB they should -DPOLYCODE_NUMBER_IS_SINGLE when compiling their own code too. Not sure if there's a tidier change for that.
