### PR TITLE
When setting matrix of an entity explicitly, fix for camera visibility check

### DIFF
--- a/Core/Contents/Source/PolyEntity.cpp
+++ b/Core/Contents/Source/PolyEntity.cpp
@@ -681,6 +681,7 @@ Number Entity::getRoll() const {
 
 void Entity::setTransformByMatrixPure(const Matrix4& matrix) {
 	transformMatrix = matrix;
+	_position = position = matrix.getPosition();
 }
 
 void Entity::setPosition(const Vector3 &posVec) {


### PR DESCRIPTION
With some of my objects I was explicitly setting their matrix every frame from another source. Doing this, the object was failing the camera's visibility check because the camera checks against the Entity::getPosition. This was the easier hack. The alternative would be to make the camera visibility check update the matrix and get the position from that, but it seemed like unnecessary extra calculation... Maybe it would be better that way around though.
