### PR TITLE
getopt include breaks the build for linux

### DIFF
--- a/Tools/Contents/polyimport/CMakeLists.txt
+++ b/Tools/Contents/polyimport/CMakeLists.txt
@@ -3,7 +3,6 @@ INCLUDE(PolycodeIncludes)
 FIND_PACKAGE(Assimp REQUIRED)
 INCLUDE_DIRECTORIES(
     ${ASSIMP_INCLUDE_DIR} 
-	${Polycode_SOURCE_DIR}/Tools/Dependencies/getopt
     Include)
 
 IF(WIN32)


### PR DESCRIPTION
When building linux, the getopt.h in the Tools/Dependencies/getopt directory was overriding the system getopt.h include, causing errors with building. This removes the include directory for it when not on windows (it's already added again a couple of lines below anyway, so should still be fine on windows).
