### PR TITLE
Uninitialized memory and leaks that valgrind was complaining about

### DIFF
--- a/Core/Contents/Include/PolyFont.h
+++ b/Core/Contents/Include/PolyFont.h
@@ -52,5 +52,8 @@ namespace Polycode {
 			unsigned char *buffer;
 			bool valid;
 			FT_Face ftFace;
+
+			static int fontAllocCount;
+			static FT_Library FTLibrary;
 	};
 }

--- a/Core/Contents/Source/PolyCore.cpp
+++ b/Core/Contents/Source/PolyCore.cpp
@@ -110,6 +110,7 @@ namespace Polycode {
 	
 	Core::~Core() {
 		printf("Shutting down core");
+		delete input;
 		delete services;
 	}
 	

--- a/Core/Contents/Source/PolyCoreServices.cpp
+++ b/Core/Contents/Source/PolyCoreServices.cpp
@@ -135,6 +135,7 @@ CoreServices::~CoreServices() {
 	delete timerManager;
 	delete tweenManager;
 	delete resourceManager;
+	delete config;
 	delete soundManager;
 	delete fontManager;
 	instanceMap.clear();

--- a/Core/Contents/Source/PolyFont.cpp
+++ b/Core/Contents/Source/PolyFont.cpp
@@ -26,12 +26,16 @@
 
 using namespace Polycode;
 
+int Font::fontAllocCount = 0;
+FT_Library Font::FTLibrary = NULL;
+
 Font::Font(const String& fileName) {
 
 	this->fileName = fileName;
 
-	FT_Library FTLibrary;
-	FT_Init_FreeType(&FTLibrary);
+	if (++fontAllocCount == 1) {
+		FT_Init_FreeType(&FTLibrary);
+	}
 	
 	loaded = false;
 	buffer = NULL;
@@ -78,6 +82,9 @@ bool Font::isValid() const {
 Font::~Font() {
 	if(buffer) {
 		free(buffer);
+	}
+	if (--fontAllocCount == 0) {
+		FT_Done_FreeType(FTLibrary);
 	}
 }
 

--- a/Core/Contents/Source/PolyScene.cpp
+++ b/Core/Contents/Source/PolyScene.cpp
@@ -54,6 +54,7 @@ void Scene::initScene(int sceneType, bool virtualScene) {
 	defaultCamera = new Camera(this);
 	activeCamera = defaultCamera;	
 	fogEnabled = false;
+	fogMode = Renderer::FOG_LINEAR;
     overrideMaterial = NULL;
 	lightingEnabled = false;
 	enabled = true;


### PR DESCRIPTION
Fixed a couple of issues as I was running my program through valgrind that were causing memory leaks/uses of uninitialized memory. I've also made the FreeType library handle auto-destruct when it's no longer needed.
