### PR TITLE
Disabled entities are not supposed to be updated

### DIFF
--- a/Core/Contents/Source/PolyEntity.cpp
+++ b/Core/Contents/Source/PolyEntity.cpp
@@ -414,10 +414,12 @@ void Entity::rebuildTransformMatrix() {
 }
 
 void Entity::doUpdates() {
-	Update();
-	for(int i=0; i < children.size(); i++) {
-		children[i]->doUpdates();
-	}	
+	if (enabled) {
+		Update();
+		for(int i=0; i < children.size(); i++) {
+			children[i]->doUpdates();
+		}
+	}
 }
 
 void Entity::updateEntityMatrix() {


### PR DESCRIPTION
Documentation states that disabled nodes don't get updated. I reckon this should be enforced by the engine as I added a bunch of particles emitters which were being disabled/enabled and it was causing quite a performance hit having them all effectively updated all the time.
