### PR TITLE
Utilities for baking scene mesh children into a parent

### DIFF
--- a/Core/Contents/Include/PolyEntity.h
+++ b/Core/Contents/Include/PolyEntity.h
@@ -35,6 +35,7 @@
 namespace Polycode {
 
 	class Renderer;
+	class Mesh;
 
 	class _PolyExport MouseEventResult {
 		public:
@@ -723,8 +724,12 @@ namespace Polycode {
 
 			bool snapToPixels;			
 			bool mouseOver;
-        
+
+			Mesh* bakeChildMeshes(Mesh* destinationMesh = NULL, Matrix4* transform = NULL);
+
             static int defaultBlendingMode;
+
+			virtual void bakeIntoMesh(Mesh* destinationMesh, const Matrix4* parentTransform) {}
 			
 			//@}		
 		protected:
@@ -735,7 +740,8 @@ namespace Polycode {
 		
 			void *userData;
 		
-			std::vector<Entity*> children;
+			typedef std::vector<Entity*> children_t;
+			children_t children;
 
 			Vector3 anchorPoint;
 			

--- a/Core/Contents/Include/PolyMesh.h
+++ b/Core/Contents/Include/PolyMesh.h
@@ -254,6 +254,10 @@ namespace Polycode {
             Vertex *getActualVertex(unsigned int index) const;
 
             unsigned int getActualVertexCount() const;
+
+			/** Copies all the faces from the mesh given into this mesh. Meshes must be the same type.
+				Optionally transforms the vertices as well. */
+			void addMesh(Mesh* sourceMesh, Matrix4* sourceTransform = NULL);
         
         
 			/**

--- a/Core/Contents/Include/PolySceneMesh.h
+++ b/Core/Contents/Include/PolySceneMesh.h
@@ -184,8 +184,10 @@ namespace Polycode {
             bool forceMaterial;
         
             virtual Entity *Clone(bool deepClone, bool ignoreEditorOnly) const;
-            virtual void applyClone(Entity *clone, bool deepClone, bool ignoreEditorOnly) const;
-			
+			virtual void applyClone(Entity *clone, bool deepClone, bool ignoreEditorOnly) const;
+
+			virtual void bakeIntoMesh(Mesh* destinationMesh, const Matrix4* parentTransform);
+
 		protected:
 		
 			bool useVertexBuffer;

--- a/Core/Contents/Include/PolyVertex.h
+++ b/Core/Contents/Include/PolyVertex.h
@@ -30,14 +30,21 @@
 namespace Polycode {
 
 	class Bone;
+	class Matrix4;
 	
 	/**
 	* Bone assignment.
 	*/ 
 	class _PolyExport BoneAssignment {
 		public:
-			BoneAssignment(){
-				bone = NULL;
+			BoneAssignment()
+			:	bone(NULL) {
+			}
+			BoneAssignment(unsigned int boneID, Number weight)
+			:	boneID(boneID)
+			,	weight(weight)
+			,	bone(NULL)
+			{
 			}
 			/**
 			* Id of the bone assigned.
@@ -159,6 +166,9 @@ namespace Polycode {
 			*/			
 			void setNormal(Number x, Number y, Number z);
 
+			/** Applies necessary transform and rotations of this vertex by the matrix given. */
+			void transformBy(Matrix4* m);
+
 			/**
 			* Rest normal.
 			*/
@@ -194,7 +204,7 @@ namespace Polycode {
 				
 		protected:
 		
-			std::vector <BoneAssignment*> boneAssignments;
+			std::vector <BoneAssignment> boneAssignments;
 		
 	};
 }

--- a/Core/Contents/Source/PolyEntity.cpp
+++ b/Core/Contents/Source/PolyEntity.cpp
@@ -23,6 +23,7 @@
 #include "PolyRenderer.h"
 #include "PolyCoreServices.h"
 #include "PolyInputEvent.h"
+#include "PolyMesh.h"
 
 using namespace Polycode;
 
@@ -232,7 +233,7 @@ void Entity::lookAt(const Vector3 &loc, const Vector3 &upVector) {
 
 void Entity::lookAtEntity(Entity *entity,  const Vector3 &upVector) {
 	if(entity->getParentEntity())
-		lookAt(entity->getParentEntity()->getConcatenatedMatrix() * (entity->getPosition()), upVector);		
+		lookAt(entity->getParentEntity()->getConcatenatedMatrix() * (entity->getPosition()), upVector);
 	else
 		lookAt(entity->getPosition(), upVector);
 }
@@ -1114,4 +1115,30 @@ MouseEventResult Entity::onMouseWheelDown(const Ray &ray, int timestamp) {
 		}
 	}
 	return ret;
+}
+
+Mesh* Entity::bakeChildMeshes(Mesh* destinationMesh, Matrix4* transform) {
+	if (destinationMesh == NULL) {
+		destinationMesh = new Mesh(Mesh::TRI_MESH);
+	}
+	updateEntityMatrix();
+	bakeIntoMesh(destinationMesh, transform);
+
+	if (!children.empty()) {
+
+		Matrix4 subTransform;
+		if (transform == NULL) {
+			transform = &transformMatrix;
+		}
+		else {
+			subTransform = transformMatrix * *transform;
+			transform = &subTransform;
+		}
+
+		for (children_t::iterator it = children.begin(); it != children.end(); it++) {
+			(*it)->bakeChildMeshes(destinationMesh, transform);
+		}
+	}
+
+	return destinationMesh;
 }

--- a/Core/Contents/Source/PolyMesh.cpp
+++ b/Core/Contents/Source/PolyMesh.cpp
@@ -1029,3 +1029,17 @@ int Mesh::getMeshType() {
 void Mesh::setMeshType(int newType) {
     meshType = newType;
 }
+
+void Mesh::addMesh(Mesh *sourceMesh, Matrix4 *sourceTransform) {
+	if (sourceMesh->meshType != meshType) {
+		Logger::logw("Mesh::addMesh Meshes not of same type!");
+	}
+
+	for (int i = 0; i < sourceMesh->getVertexCount(); i++) {
+		Vertex* vertex = new Vertex(*sourceMesh->getVertex(i));
+		if (sourceTransform) {
+			vertex->transformBy(sourceTransform);
+		}
+		addVertex(vertex);
+	}
+}

--- a/Core/Contents/Source/PolySceneMesh.cpp
+++ b/Core/Contents/Source/PolySceneMesh.cpp
@@ -384,3 +384,13 @@ void SceneMesh::Render() {
 	}	
     renderer->setWireframePolygonMode(false);    
 }
+
+void SceneMesh::bakeIntoMesh(Mesh* destinationMesh, const Matrix4* parentTransform) {
+	if (parentTransform != NULL) {
+		Matrix4 tempMatrix = transformMatrix * (*parentTransform);
+		destinationMesh->addMesh(mesh, &tempMatrix);
+	}
+	else {
+		destinationMesh->addMesh(mesh, &transformMatrix);
+	}
+}


### PR DESCRIPTION
Added functions to easily allow baking hierachy of scene meshes in situ into one Mesh. Also changed ownership of BoneAssignment to be more cleanly part of Vertex and not memory leak. 
