### PR TITLE
Particle emitter default update rate should match frame rate

### DIFF
--- a/Core/Contents/Include/PolyCore.h
+++ b/Core/Contents/Include/PolyCore.h
@@ -308,7 +308,12 @@ namespace Polycode {
 		* Returns the total ticks elapsed since launch.
 		* @return Time elapsed since launch in milliseconds
 		*/						
-		virtual unsigned int getTicks() = 0;		
+		virtual unsigned int getTicks() = 0;
+
+		/** Returns the target number of milliseconds between frames */
+		long getRefreshIntervalMs() const {
+			return refreshInterval;
+		}
 		
 		/**
 		* Returns the total ticks elapsed since launch.

--- a/Core/Contents/Source/PolyParticleEmitter.cpp
+++ b/Core/Contents/Source/PolyParticleEmitter.cpp
@@ -28,9 +28,10 @@
 
 using namespace Polycode;
 
-SceneParticleEmitter::SceneParticleEmitter(unsigned int particleCount, Number lifetime, Number speed) : SceneMesh(Mesh::POINT_MESH), particleCount(particleCount), particleSpeed(speed), lifetime(lifetime), directionVector(0.0, 1.0, 0.0), timeStep(0.01666), cyclesLeftOver(0.0), useFloorPlane(false), floorPlaneOffset(-1.0), floorDamping(0.5), particlesInWorldSpace(false), perlinEnabled(false), perlinValue(1.0,1.0,1.0), particleType(SceneParticleEmitter::PARTICLE_TYPE_POINT), particleSize(0.1), particleRotationSpeed(0.0, 0.0, 0.0), useColorCurves(false), useScaleCurve(false), loopParticles(true){
+SceneParticleEmitter::SceneParticleEmitter(unsigned int particleCount, Number lifetime, Number speed) : SceneMesh(Mesh::POINT_MESH), particleCount(particleCount), particleSpeed(speed), lifetime(lifetime), directionVector(0.0, 1.0, 0.0), cyclesLeftOver(0.0), useFloorPlane(false), floorPlaneOffset(-1.0), floorDamping(0.5), particlesInWorldSpace(false), perlinEnabled(false), perlinValue(1.0,1.0,1.0), particleType(SceneParticleEmitter::PARTICLE_TYPE_POINT), particleSize(0.1), particleRotationSpeed(0.0, 0.0, 0.0), useColorCurves(false), useScaleCurve(false), loopParticles(true){
     
     core = CoreServices::getInstance()->getCore();
+	timeStep = core->getRefreshIntervalMs() / 1000.0f;
     motionPerlin = new Perlin(3,5,1.0,RANDOM_NUMBER);
     mesh->useVertexColors = true;
     depthWrite = false;


### PR DESCRIPTION
Changed the hard-coded default particle emitter timeStep from assumed 60FPS to the actual frame interval in use. This avoids unnecessary multi-step particle emitter updates. 
