### PR TITLE
Remove EventHandler::secondaryHandler()

### DIFF
--- a/Core/Contents/Include/PolyEventHandler.h
+++ b/Core/Contents/Include/PolyEventHandler.h
@@ -37,18 +37,15 @@ namespace Polycode {
 			EventHandler();
 			virtual ~EventHandler();
 
-		void secondaryHandler(Event *event);		
-		
-		/** 
-		* This method gets called by an EventDispatcher that the handler is listening to if the dispatching event's code matches the code that handler is listening for. Typically, you subclass EventHandler and implement the handleEvent method to handle specific events.
-		* @see EventDispatcher
-		*/
-		virtual void handleEvent(Event *event){}
-			
-		void *secondaryHandlerData;
-		
-		
-		protected:
-	
+			/**
+			 * This method gets called by an @c EventDispatcher that the handler is listening to if the
+			 * dispatching event's code matches the code that handler is listening for. Typically, you
+			 * subclass @c EventHandler and implement the @c handleEvent method to handle specific events.
+			 *
+			 * @param event Event, event handler was listening for
+			 *
+			 * @see EventDispatcher
+			 */
+			virtual void handleEvent(Event *event) {}
 	};
 }

--- a/Core/Contents/Source/PolyEventDispatcher.cpp
+++ b/Core/Contents/Source/PolyEventDispatcher.cpp
@@ -73,7 +73,6 @@ namespace Polycode {
 				//					handlerEntries[i].handler->onEvent(event);
 				//				}
 				handlerEntries[i].handler->handleEvent(event);
-				handlerEntries[i].handler->secondaryHandler(event);
 			}
 		}
 		

--- a/Core/Contents/Source/PolyEventHandler.cpp
+++ b/Core/Contents/Source/PolyEventHandler.cpp
@@ -28,9 +28,6 @@ namespace Polycode {
 	EventHandler::EventHandler() {
 	}
 	
-	void EventHandler::secondaryHandler(Event *event) {
-	}	
-	
 	EventHandler::~EventHandler() {
 		
 	}


### PR DESCRIPTION
This method is never used by Polycode itself and is redundant.
