### PR TITLE
Null out parent reference when child is removed

### DIFF
--- a/Core/Contents/Source/PolyEntity.cpp
+++ b/Core/Contents/Source/PolyEntity.cpp
@@ -257,6 +257,7 @@ void Entity::removeChild(Entity *entityToRemove) {
 		if(children[i] == entityToRemove) {
             entityToRemove->setParentEntity(NULL);
 			children.erase(children.begin()+i);
+			entityToRemove->parentEntity = NULL;
 			return;
 		}
 	}	


### PR DESCRIPTION
This was causing me to have bugs - when you remove an entity, the parentEntity pointer should then be null. 
