### PR TITLE
Added Matrix multiplyWithPerspective method, 

### DIFF
--- a/Core/Contents/Include/PolyMatrix4.h
+++ b/Core/Contents/Include/PolyMatrix4.h
@@ -108,6 +108,12 @@ namespace Polycode {
 				return pos;
 			}
 
+			inline Vector3 multiplyWithPerspective(const Vector3 &v2) const
+			{
+				Number divisor = v2.x*m[0][3] + v2.y*m[1][3] + v2.z*m[2][3] + m[3][3];
+				return (*this * v2) / divisor;
+			}
+
 			// ----------------------------------------------------------------------------------------------------------------
 			/** @name Operators
 			*  Available vector operators.


### PR DESCRIPTION
The default multiply function by a Vector3 only handle the affine case. It can also be useful to do a full perspective correction sometimes, so this is here.
