### PR TITLE
No need to completely delete and re-generate texture id when recreating.

### DIFF
--- a/Core/Contents/Source/PolyGLTexture.cpp
+++ b/Core/Contents/Source/PolyGLTexture.cpp
@@ -66,11 +66,10 @@ void OpenGLTexture::recreateFromImageData() {
 	
 	Number anisotropy = CoreServices::getInstance()->getRenderer()->getAnisotropyAmount();
 	
-	if(glTextureLoaded) {
-		glDeleteTextures(1, &textureID);
+	if (!glTextureLoaded) {
+		glGenTextures(1, &textureID);
 	}
 	
-	glGenTextures(1, &textureID);
 	glBindTexture(GL_TEXTURE_2D, textureID);
 	
 	if(clamp) {


### PR DESCRIPTION
Can simply re-use the same ID. This makes hot-loading textures for shaders work a bit cleaner as the texture IDs are preserved.
