### PR TITLE
Fix virtual functions in Linux PolycodePlayer

### DIFF
--- a/Core/Contents/Include/PolySDLCore.h
+++ b/Core/Contents/Include/PolySDLCore.h
@@ -49,9 +49,9 @@ namespace Polycode {
 		void enableMouse(bool newval);
 		void captureMouse(bool);
 		unsigned int getTicks();
-		bool Update();
+		bool systemUpdate();
 		void Render();
-		void setVideoMode(int xRes, int yRes, bool fullScreen, bool vSync, int aaLevel, int anisotropyLevel);
+		void setVideoMode(int xRes, int yRes, bool fullScreen, bool vSync, int aaLevel, int anisotropyLevel, bool retinaSupport = true);
 		void createThread(Threaded *target);
 		std::vector<Rectangle> getVideoModes();
 		
@@ -68,6 +68,7 @@ namespace Polycode {
 		void removeDiskItem(const String& itemPath);
 		String openFolderPicker();
 		std::vector<String> openFilePicker(std::vector<CoreFileExtension> extensions, bool allowMultiple);
+                String saveFilePicker(std::vector<CoreFileExtension> extensions);
 		void resizeTo(int xRes, int yRes);
 
 		String executeExternalCommand(String command, String args, String inDirectory="");

--- a/Core/Contents/Source/PolySDLCore.cpp
+++ b/Core/Contents/Source/PolySDLCore.cpp
@@ -133,7 +133,7 @@ SDLCore::SDLCore(PolycodeView *view, int _xRes, int _yRes, bool fullScreen, bool
 	CoreServices::getInstance()->installModule(new GLSLShaderModule());	
 }
 
-void SDLCore::setVideoMode(int xRes, int yRes, bool fullScreen, bool vSync, int aaLevel, int anisotropyLevel) {
+void SDLCore::setVideoMode(int xRes, int yRes, bool fullScreen, bool vSync, int aaLevel, int anisotropyLevel, bool retinaSupport) {
 	this->xRes = xRes;
 	this->yRes = yRes;
 	this->fullScreen = fullScreen;
@@ -313,7 +313,7 @@ void SDLCore::Render() {
 	SDL_GL_SwapBuffers();
 }
 
-bool SDLCore::Update() {
+bool SDLCore::systemUpdate() {
 	if(!running)
 		return false;
 	doSleep();	
@@ -497,6 +497,11 @@ String SDLCore::openFolderPicker() {
 vector<String> SDLCore::openFilePicker(vector<CoreFileExtension> extensions, bool allowMultiple) {
 	vector<String> r;
 	return r;
+}
+
+String SDLCore::saveFilePicker(std::vector<CoreFileExtension> extensions) {
+        String r = "";
+        return r;
 }
 
 void SDLCore::resizeTo(int xRes, int yRes) {


### PR DESCRIPTION
I got this error while executing BuildLinux.sh:

Scanning dependencies of target PolycodePlayer
[ 95%] Building CXX object Player/Contents/CMakeFiles/PolycodePlayer.dir/Source/PolycodePlayer.cpp.o
[ 95%] Building CXX object Player/Contents/CMakeFiles/PolycodePlayer.dir/Source/PolycodeLinuxPlayer.cpp.o  
/home/xxxxxxxxxx/workspace/Polycode/Player/Contents/Source/PolycodeLinuxPlayer.cpp: In member function ‘virtual void PolycodeLinuxPlayer::createCore()’:
/home/xxxxxxxxxx/workspace/Polycode/Player/Contents/Source/PolycodeLinuxPlayer.cpp:34:81: error: invalid new-expression of abstract class type ‘Polycode::SDLCore’
  core =  new SDLCore(view, xRes, yRes,  fullScreen, false, aaLevel, 0, frameRate); 
                                                                                 ^
In file included from /home/xxxxxxxxxx/workspace/Polycode/Core/Contents/PolycodeView/Linux/PolycodeView.h:3:0,
                 from /home/xxxxxxxxxx/workspace/Polycode/Player/Contents/Include/PolycodeLinuxPlayer.h:25,
                 from /home/xxxxxxxxxx/workspace/Polycode/Player/Contents/Source/PolycodeLinuxPlayer.cpp:22:
/home/xxxxxxxxxx/workspace/Polycode/Core/Contents/Include/PolySDLCore.h:42:20: note:   because the following virtual functions are pure within ‘Polycode::SDLCore’:
  class _PolyExport SDLCore : public Core {
                    ^
In file included from /home/xxxxxxxxxx/workspace/Polycode/Core/Contents/Include/PolySDLCore.h:26:0,
                 from /home/xxxxxxxxxx/workspace/Polycode/Core/Contents/PolycodeView/Linux/PolycodeView.h:3,
                 from /home/xxxxxxxxxx/workspace/Polycode/Player/Contents/Include/PolycodeLinuxPlayer.h:25,
                 from /home/xxxxxxxxxx/workspace/Polycode/Player/Contents/Source/PolycodeLinuxPlayer.cpp:22:
/home/xxxxxxxxxx/workspace/Polycode/Core/Contents/Include/PolyCore.h:99:22: note:      virtual bool Polycode::Core::systemUpdate()
         virtual bool systemUpdate() = 0;
                      ^
/home/xxxxxxxxxx/workspace/Polycode/Core/Contents/Include/PolyCore.h:282:18: note:     virtual Polycode::String Polycode::Core::saveFilePicker(std::vectorPolycode::CoreFileExtension)
   virtual String saveFilePicker(std::vector<CoreFileExtension> extensions) = 0;
                  ^
/home/xxxxxxxxxx/workspace/Polycode/Core/Contents/Include/PolyCore.h:292:16: note:     virtual void Polycode::Core::setVideoMode(int, int, bool, bool, int, int, bool)
   virtual void setVideoMode(int xRes, int yRes, bool fullScreen, bool vSync, int aaLevel, int anisotropyLevel, bool retinaSupport=true) = 0;
                ^
Player/Contents/CMakeFiles/PolycodePlayer.dir/build.make:80: recipe for target 'Player/Contents/CMakeFiles/PolycodePlayer.dir/Source/PolycodeLinuxPlayer.cpp.o' failed
make[2]: **\* [Player/Contents/CMakeFiles/PolycodePlayer.dir/Source/PolycodeLinuxPlayer.cpp.o] Error 1
CMakeFiles/Makefile2:774: recipe for target 'Player/Contents/CMakeFiles/PolycodePlayer.dir/all' failed
make[1]: **\* [Player/Contents/CMakeFiles/PolycodePlayer.dir/all] Error 2
Makefile:136: recipe for target 'all' failed
make: **\* [all] Error 2
