### PR TITLE
Win32Core::openFilePicker fixes

### DIFF
--- a/Core/Contents/Include/PolyWinCore.h
+++ b/Core/Contents/Include/PolyWinCore.h
@@ -38,7 +38,6 @@
 
 
 #include <vector>
-#include <sstream>
 
 #ifndef VK_0
 #define VK_0	'0'

--- a/Core/Contents/Source/PolyWinCore.cpp
+++ b/Core/Contents/Source/PolyWinCore.cpp
@@ -1147,11 +1147,26 @@ std::vector<String> Win32Core::openFilePicker(std::vector<CoreFileExtension> ext
 
 	if(GetOpenFileName(&ofn)) {
 		if(allowMultiple) {
+			String path = fBuffer;
+
 			std::string buf;
-			std::stringstream filesList(String(fBuffer).getSTLString());
-			
-			while (filesList >> buf)
-				retVec.push_back(buf);
+			for (int i = ofn.nFileOffset; i < sizeof( fBuffer ); i++)
+			{
+				if (fBuffer[i] != NULL)
+					buf.push_back(fBuffer[i]);
+				else if (fBuffer[i-1] != NULL)
+				{
+					retVec.push_back(path + "/" + buf);
+					buf = "";
+				}
+				else // 2 NULL characters = no more files
+					break;
+			}
+			if (retVec.size() == 1)
+			{
+				retVec.clear();
+				retVec.push_back(path); // If only 1 file selected, path is the full path of the file
+			}
 		} else {
 			retVec.push_back(String(fBuffer));
 		}


### PR DESCRIPTION
Without this patch, the "Add external files" button of the IDE doesn't
work, because the function return an empty files list.
