### PR TITLE
Have cmake create documentation directories so doxygen doesn't complain

### DIFF
--- a/Documentation/CMakeLists.txt
+++ b/Documentation/CMakeLists.txt
@@ -11,6 +11,7 @@ FILE(GLOB HEADER_DEPENDENCIES_UI ${Polycode_SOURCE_DIR}/Modules/Contents/UI/Incl
 
 ADD_CUSTOM_COMMAND(
 OUTPUT doc_cmd
+COMMAND mkdir -p ${Polycode_SOURCE_DIR}/Documentation/Doxygen/output/standalone/{Polycode,Physics2D,Physics3D,PolycodeUI}
 COMMAND ${DOXYGEN_EXECUTABLE} ${Polycode_SOURCE_DIR}/Documentation/Doxygen/Polycode.doxygen
 COMMAND ${DOXYGEN_EXECUTABLE} ${Polycode_SOURCE_DIR}/Documentation/Doxygen/Physics2D.doxygen
 COMMAND ${DOXYGEN_EXECUTABLE} ${Polycode_SOURCE_DIR}/Documentation/Doxygen/Physics3D.doxygen


### PR DESCRIPTION
This fixes the issue of a clean install where the doxygen output directories don't exist.  Without this, one hits the error:
```
error: tag OUTPUT_DIRECTORY: Output directory `./output/standalone/Polycode' does not exist and cannot be created
```

This was hit by [someone other than me](http://polycode.org/forum/viewtopic.php?f=4&t=1192), so I'm pretty sure it's not just me.  ;)