### PR TITLE
Windows 8+ Pointer events for multitouch and pen detection.

### DIFF
--- a/Core/Contents/Include/PolyCoreInput.h
+++ b/Core/Contents/Include/PolyCoreInput.h
@@ -171,6 +171,11 @@ namespace Polycode {
 		*/
 		bool simulateTouchWithMouse;
 
+		/**
+		* If set to true, simulated touches will have type TYPE_PEN.
+		*/
+		bool simulateTouchAsPen;
+
         /**
          * If set to true, will fire mouse events on touch input. Defaults to false.
          */

--- a/Core/Contents/Include/PolyInputEvent.h
+++ b/Core/Contents/Include/PolyInputEvent.h
@@ -29,11 +29,17 @@ THE SOFTWARE.
 namespace Polycode {
 
 	class TouchInfo { 
-		public:			
+		public:
+			static const int TYPEBASE = 0x500;
+			static const int TYPE_TOUCH = TYPEBASE + 0;
+			static const int TYPE_PEN = TYPEBASE + 1;
+
+			TouchInfo();
+
 			int id;
 			Vector2 position;
 			int type;
-			int flag;
+			unsigned long flags;
 	};	
 
 	/*
@@ -88,12 +94,7 @@ namespace Polycode {
 		static const int EVENT_POINTERS_BEGAN = EVENTBASE_INPUTEVENT + 23;
 		static const int EVENT_POINTERS_MOVED = EVENTBASE_INPUTEVENT + 24;
 		static const int EVENT_POINTERS_ENDED = EVENTBASE_INPUTEVENT + 25;
-
-		static const int TYPEBASE = 0x500;
-		static const int TYPE_FINGER = TYPEBASE + 0;
-		static const int TYPE_PEN = TYPEBASE + 1;
-		
-		
+	
 		//@}
 		// ----------------------------------------------------------------------------------------------------------------
 		
@@ -129,7 +130,8 @@ namespace Polycode {
 		
 		std::vector<TouchInfo> touches;
 		TouchInfo touch;
-		
+		int touchType;
+
 		unsigned int joystickDeviceID;
 		float joystickAxisValue;
 		unsigned int joystickButton;

--- a/Core/Contents/Include/PolyInputEvent.h
+++ b/Core/Contents/Include/PolyInputEvent.h
@@ -32,7 +32,18 @@ namespace Polycode {
 		public:			
 			int id;
 			Vector2 position;
+			int type;
+			int flag;
 	};	
+
+	/*
+	class PointerInfo {
+	public:
+		int id;
+		Vector2 position;
+		int flag;
+	};
+	*/
 
 	/**
 	* Event dispatched by CoreInput. This event is dispatched by CoreInput when input happens.
@@ -73,6 +84,14 @@ namespace Polycode {
 		static const int EVENT_TOUCHES_BEGAN = EVENTBASE_INPUTEVENT+20;
 		static const int EVENT_TOUCHES_MOVED = EVENTBASE_INPUTEVENT+21;
 		static const int EVENT_TOUCHES_ENDED = EVENTBASE_INPUTEVENT+22;
+
+		static const int EVENT_POINTERS_BEGAN = EVENTBASE_INPUTEVENT + 23;
+		static const int EVENT_POINTERS_MOVED = EVENTBASE_INPUTEVENT + 24;
+		static const int EVENT_POINTERS_ENDED = EVENTBASE_INPUTEVENT + 25;
+
+		static const int TYPEBASE = 0x500;
+		static const int TYPE_FINGER = TYPEBASE + 0;
+		static const int TYPE_PEN = TYPEBASE + 1;
 		
 		
 		//@}

--- a/Core/Contents/Include/PolyWinCore.h
+++ b/Core/Contents/Include/PolyWinCore.h
@@ -95,8 +95,12 @@
 
 #define EXTENDED_KEYMASK	(1<<24)
 
+//#define NO_TOUCH_API
+#define NO_PEN_API
+
 #ifdef _MINGW
 #define NO_TOUCH_API 1
+#define NO_PEN_API 1
 #endif
 
 #define POLYCODE_CORE Win32Core

--- a/Core/Contents/Include/PolyWinCore.h
+++ b/Core/Contents/Include/PolyWinCore.h
@@ -116,6 +116,7 @@ namespace Polycode {
 		int mouseY;
 		TouchInfo touch;
 		std::vector<TouchInfo> touches;
+		int touchType;
 		PolyKEY keyCode;
 		wchar_t unicodeChar;		
 		char mouseButton;	
@@ -193,6 +194,7 @@ public:
 		void handleMouseDown(int mouseCode,LPARAM lParam, WPARAM wParam);
 		void handleMouseUp(int mouseCode,LPARAM lParam, WPARAM wParam);
 		void handleTouchEvent(LPARAM lParam, WPARAM wParam);
+		void handlePointerUpdate(LPARAM lParam, WPARAM wParam);
 
 		bool isMultiTouchEnabled() { return hasMultiTouch; }
 

--- a/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
+++ b/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
@@ -107,6 +107,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 	break;
 #endif
 
+	case WM_POINTERUPDATE:
+		if (core)
+			core->handlePointerUpdate(lParam, wParam);
+	break;
+
 	case WM_MBUTTONDOWN:
 		if(core)
 			core->handleMouseDown(CoreInput::MOUSE_BUTTON3, lParam,wParam);

--- a/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
+++ b/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
@@ -97,25 +97,25 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			core->handleMouseUp(CoreInput::MOUSE_BUTTON2, lParam,wParam);
 	break;
 
-	/*
-#ifndef NO_TOUCH_API
-	case WM_TOUCH:
-		if(core) {
-			if(core->isMultiTouchEnabled()) {
-				core->handleTouchEvent(lParam, wParam);
+#ifndef NO_TOUCH_API 
+	#ifdef NO_PEN_API
+		case WM_TOUCH:
+			if(core) {
+				if(core->isMultiTouchEnabled()) {
+					core->handleTouchEvent(lParam, wParam);
+				}
 			}
-		}
-	break;
+		break;
+	#else
+		case WM_POINTERUPDATE:
+		case WM_POINTERUP:
+		case WM_POINTERDOWN:
+			if (core)
+				core->handlePointerUpdate(lParam, wParam);
+		break;
+	#endif
 #endif
-	*/
 	
-	case WM_POINTERUPDATE:
-	case WM_POINTERUP:
-	case WM_POINTERDOWN:
-		if (core)
-			core->handlePointerUpdate(lParam, wParam);
-	break;
-
 	case WM_MBUTTONDOWN:
 		if(core)
 			core->handleMouseDown(CoreInput::MOUSE_BUTTON3, lParam,wParam);

--- a/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
+++ b/Core/Contents/PolycodeView/MSVC/PolycodeView.cpp
@@ -97,6 +97,7 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 			core->handleMouseUp(CoreInput::MOUSE_BUTTON2, lParam,wParam);
 	break;
 
+	/*
 #ifndef NO_TOUCH_API
 	case WM_TOUCH:
 		if(core) {
@@ -106,8 +107,11 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 		}
 	break;
 #endif
-
+	*/
+	
 	case WM_POINTERUPDATE:
+	case WM_POINTERUP:
+	case WM_POINTERDOWN:
 		if (core)
 			core->handlePointerUpdate(lParam, wParam);
 	break;

--- a/Core/Contents/Source/PolyCoreInput.cpp
+++ b/Core/Contents/Source/PolyCoreInput.cpp
@@ -294,6 +294,12 @@ namespace Polycode {
 			setMousePosition(touch.position.x, touch.position.y, ticks);
 		}
 	}
+
+
+
+
+
+
 	
 	void CoreInput::touchesEnded(TouchInfo touch, std::vector<TouchInfo> touches, int ticks) {
 		if(ignoreOffScreenTouch) {

--- a/Core/Contents/Source/PolyCoreInput.cpp
+++ b/Core/Contents/Source/PolyCoreInput.cpp
@@ -40,6 +40,7 @@ namespace Polycode {
 	CoreInput::CoreInput() : EventDispatcher() {
 		clearInput();
 		simulateTouchWithMouse = false;
+		simulateTouchAsPen = false;
 		simulateMouseWithTouch = false;
 		ignoreOffScreenTouch = false;
         keyRepeat = true;
@@ -174,7 +175,10 @@ namespace Polycode {
 		if(simulateTouchWithMouse) {
 			TouchInfo touch;
 			touch.position = mousePosition;
-			touch.id = 0;			
+			touch.id = 0;
+			if (simulateTouchAsPen){
+				touch.type = TouchInfo::TYPE_PEN;
+			}
 			std::vector<TouchInfo> touches;
 			touches.push_back(touch);
 			
@@ -203,13 +207,15 @@ namespace Polycode {
 		dispatchEvent(evt, InputEvent::EVENT_MOUSEMOVE);
 		
 		if(simulateTouchWithMouse) {
-		
-		
-		
+
 			TouchInfo touch;
 			touch.position = mousePosition;
 			touch.id = 0;			
+			if (simulateTouchAsPen){
+				touch.type = TouchInfo::TYPE_PEN;
+			}
 			std::vector<TouchInfo> touches;
+
 			touches.push_back(touch);
 
             /*

--- a/Core/Contents/Source/PolyInputEvent.cpp
+++ b/Core/Contents/Source/PolyInputEvent.cpp
@@ -24,6 +24,9 @@
 
 namespace Polycode {
 
+TouchInfo::TouchInfo() : type(TYPE_TOUCH) {
+}
+
 InputEvent::InputEvent() : Event() {
 	eventType = "InputEvent";
 }


### PR DESCRIPTION
Adds a "type" property to touches that is either TouchInfo::TYPE_TOUCH or TouchInfo::TYPE_PEN.

Disabled in PolyWinCore.h by default. Comment out line 99's NO_PEN_API definition to build with Windows 8+ Pointer events.