### PR TITLE
overflow of int issue in startup

### DIFF
--- a/Core/Contents/Source/PolyCore.cpp
+++ b/Core/Contents/Source/PolyCore.cpp
@@ -275,7 +275,7 @@ namespace Polycode {
 	void Core::doSleep() {
 		unsigned int ticks = getTicks();
 		unsigned int ticksSinceLastFrame = ticks - lastSleepFrameTicks;
-		int sleepTimeMs = refreshInterval - ticksSinceLastFrame;
+		long long sleepTimeMs = refreshInterval - ticksSinceLastFrame;
 		if(sleepTimeMs > 0) {
 #ifdef _WINDOWS
 			Sleep(sleepTimeMs);


### PR DESCRIPTION
If the tick count is too large the calculation overflows the signed int and therefore becomes a large positive number, this means the system hangs indefinitely.

This was causing a few issues as myself and my friends tend to hibernate between coding sessions.