### PR TITLE
Add commandline argument (-d or --debug) to Windows Studio to log to file

### DIFF
--- a/build/windows/win32/PolycodeStudio/main.cpp
+++ b/build/windows/win32/PolycodeStudio/main.cpp
@@ -41,8 +41,7 @@ void registerFileType(String extension, String progId, String app, String defaul
 
 }
 
-int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow)
-{
+int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLine, int nCmdShow){
 
 	ChangeWindowMessageFilter(WM_COPYDATA,MSGFLT_ADD);
 
@@ -55,6 +54,13 @@ int APIENTRY WinMain(HINSTANCE hInstance, HINSTANCE hPrevInstance, LPSTR lpCmdLi
 	}
 
 	fileName = fileName.replace("\\", "/");
+
+	String arg;
+	for (int i = 1; i < nArgs; i++) {
+		arg = String(szArglist[i]);
+		if (arg == "-d" || arg == "--debug")
+			Logger::getInstance()->setLogToFile(true);
+	}
 
 	// check if an instance of Polycode is running and bring it up and open file if needed
 	HWND runningHwnd = FindWindow(L"POLYCODEAPPLICATION", L"Polycode");

--- a/src/core/PolyLogger.cpp
+++ b/src/core/PolyLogger.cpp
@@ -119,13 +119,16 @@ void Logger::setLogToFile(bool val){
 		time_t t = time(NULL);
 		char mbstr[100];
 		if (strftime(mbstr, sizeof(mbstr), "%y_%m_%d.log", localtime(&t))) {
-			logFile = fopen((const char*)mbstr, "w");
+			logFile = fopen((const char*)mbstr, "a");
 		} else {
-			logFile = fopen("poly.log", "w");
+			logFile = fopen("poly.log", "a");
 		}
+		strftime(mbstr, sizeof(mbstr), "%y_%m_%d %H:%M", localtime(&t));
+		logToFile = val;
+		Logger::log("== Starting Logging %s ==\n\n", mbstr);
+	} else {
+		logToFile = val;
 	}
-
-	logToFile = val;
 }
 
 void Logger::setLogFile(FILE *f){


### PR DESCRIPTION
Logger's option to logToFile now appends instead of overriding the old file from the day again. The first message logged to file also informs about the time, when logging to file started.
